### PR TITLE
Melhorias do builder: hero isolado, aranhas, ícones, containers e Ima…

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -429,6 +429,37 @@
     height: auto;
 }
 
+.vitrine-block-preview-placeholder--aranha {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 72px;
+    padding: 16px 12px;
+    text-align: center;
+    color: #646970;
+    background: #f6f7f7;
+    border: 1px dashed #c3c4c7;
+    border-radius: 6px;
+}
+.vitrine-block-preview-placeholder--aranha .dashicons {
+    font-size: 28px;
+    width: 28px;
+    height: 28px;
+    color: #8c8f94;
+}
+.vitrine-block-preview-placeholder--aranha .vitrine-block-preview-placeholder__label {
+    font-size: 13px;
+    font-weight: 600;
+    color: #1d2327;
+}
+.vitrine-block-preview-placeholder--aranha small {
+    font-size: 11px;
+    color: #8c8f94;
+    line-height: 1.4;
+}
+
 /* ── Handle de redimensionamento (altura – inferior) ── */
 .vitrine-resize-handle {
     position: absolute;
@@ -732,6 +763,45 @@ body.vitrine-resizing-width {
 }
 
 /* ── Aranha: painel de itens repetíveis ── */
+.vitrine-aranha-items-list {
+    min-height: 28px;
+    margin-bottom: 8px;
+}
+.vitrine-aranha-items-list:empty {
+    min-height: 36px;
+    border: 1px dashed #dcdcde;
+    border-radius: 4px;
+    background: #fafafa;
+}
+.vitrine-aranha-zone-section {
+    margin-bottom: 14px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #ececec;
+}
+.vitrine-aranha-zone-section:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+.vitrine-aranha-zone-title {
+    margin: 0 0 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #50575e;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+.vitrine-aranha-zone-count {
+    font-weight: 400;
+    color: #8c8f94;
+    text-transform: none;
+    letter-spacing: 0;
+}
+.vitrine-aranha-zone-section .vitrine-aranha-add-item {
+    margin-bottom: 4px;
+}
+.vitrine-aranha-drag-hint {
+    line-height: 1.5;
+}
 .vitrine-aranha-section-title {
     margin: 0 0 8px;
     font-size: 13px;
@@ -792,7 +862,13 @@ body.vitrine-resizing-width {
 .vitrine-aranha-item .vitrine-field-group:last-child {
     margin-bottom: 0;
 }
-.vitrine-aranha-item .vitrine-field-group label {
+.vitrine-aranha-item .vitrine-field-group--full .wp-editor-wrap,
+.vitrine-aranha-item .vitrine-field-group--full .wp-editor-container {
+    max-width: 100%;
+}
+.vitrine-aranha-item .mce-edit-area iframe {
+    min-height: 80px !important;
+}
     font-size: 11px;
     margin-bottom: 2px;
 }
@@ -1156,7 +1232,7 @@ body.vitrine-resizing-width {
     display: flex;
     flex-wrap: wrap;
     gap: 2px;
-    max-height: 150px;
+    max-height: 220px;
     overflow-y: auto;
 }
 .vitrine-icon-pick {
@@ -1224,18 +1300,9 @@ body.vitrine-resizing-width {
     box-shadow: 0 0 0 1px #2271b1;
 }
 
-/* ── Hero Settings (editor admin) ── */
-#vitrine-hero-settings {
-    background: #f6f7f7;
-    border: 1px solid #c3c4c7;
-    border-radius: 6px;
-    padding: 12px 16px;
-    margin-bottom: 12px;
-}
-#vitrine-hero-settings h4 {
-    margin: 0 0 10px;
-    font-size: 13px;
-    font-weight: 600;
+/* ── Hero Settings (meta box admin) ── */
+#vitrine-hero-meta-box {
+    padding: 4px 0;
 }
 .vitrine-hero-fields {
     display: flex;

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -261,37 +261,33 @@
     width: 100%;
 }
 
-.vitrine-imagelinks-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+.vitrine-imagelinks-content {
+    color: var(--il-content-color, #333);
+    font-size: var(--il-content-size, 14px);
+    line-height: 1.55;
 }
 
-.vitrine-imagelinks-item {
+.vitrine-imagelinks-content p {
     margin: 0 0 8px;
-    padding: 0;
-    line-height: 1.45;
 }
 
-.vitrine-imagelinks-item:last-child {
+.vitrine-imagelinks-content p:last-child {
     margin-bottom: 0;
 }
 
-.vitrine-imagelinks-link {
-    color: var(--il-link-color, #333);
-    font-size: var(--il-link-size, 14px);
-    text-decoration: underline;
-    transition: opacity 0.2s ease;
+.vitrine-imagelinks-content ul,
+.vitrine-imagelinks-content ol {
+    margin: 0 0 8px;
+    padding-left: 1.4em;
 }
 
-.vitrine-imagelinks-link:hover {
+.vitrine-imagelinks-content a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+.vitrine-imagelinks-content a:hover {
     opacity: 0.75;
-    color: var(--il-link-color, #333);
-}
-
-.vitrine-imagelinks-link--text {
-    text-decoration: underline;
-    cursor: default;
 }
 
 /* Imagem */

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -16,22 +16,12 @@
     var layout     = vitrineData.layout || [];
     var elements   = vitrineData.elements || {};
     var selectedId = null;
-    var pageSettings = vitrineData.pageSettings || {
-        show_header: '1',
-        show_footer: '1',
-        page_bg_color: '',
-        hero_image: '',
-        hero_text: '',
-        hero_text_color: '#ffffff',
-        hero_overlay_opacity: '50',
-        hero_height: '400',
-        hero_font_size: '36',
-        hero_text_align: 'center',
-        hero_description: '',
-        hero_desc_size: '18',
-        hero_text_bold: '1',
-        hero_text_italic: '0',
-        custom_css: ''
+    var rawPage = vitrineData.pageSettings || {};
+    var pageSettings = {
+        show_header:   rawPage.show_header !== undefined ? rawPage.show_header : '1',
+        show_footer:   rawPage.show_footer !== undefined ? rawPage.show_footer : '1',
+        page_bg_color: rawPage.page_bg_color || '',
+        custom_css:    rawPage.custom_css || ''
     };
 
     /* ──────────── Listas de ícones para o picker ──────────── */
@@ -108,6 +98,43 @@
         'fab fa-tiktok','fab fa-pinterest','fab fa-github'
     ];
 
+    function getDashiconsList() {
+        if (vitrineData.iconPicker && vitrineData.iconPicker.dashicons && vitrineData.iconPicker.dashicons.length) {
+            return vitrineData.iconPicker.dashicons;
+        }
+        return DASHICONS_LIST;
+    }
+
+    function getFaIconsList() {
+        if (vitrineData.iconPicker && vitrineData.iconPicker.fontawesome && vitrineData.iconPicker.fontawesome.length) {
+            return vitrineData.iconPicker.fontawesome;
+        }
+        return FA_ICONS_LIST;
+    }
+
+    function populateIconGrid($grid, tab) {
+        if (!$grid || !$grid.length) return;
+        var html = '';
+        if (tab === 'dashicons') {
+            getDashiconsList().forEach(function (d) {
+                html += '<button type="button" class="vitrine-icon-pick" data-icon="' + escapeAttr(d) + '" title="' + escapeAttr(d) + '"><span class="dashicons ' + escapeAttr(d) + '"></span></button>';
+            });
+        } else if (tab === 'fa') {
+            getFaIconsList().forEach(function (f) {
+                html += '<button type="button" class="vitrine-icon-pick" data-icon="' + escapeAttr(f) + '" title="' + escapeAttr(f) + '"><i class="' + escapeAttr(f) + '"></i></button>';
+            });
+        }
+        $grid.html(html);
+    }
+
+    function ensureIconGrid($picker, tab) {
+        if (!$picker || !$picker.length || tab === 'upload') return;
+        var $panel = $picker.find('.vitrine-icon-tab-panel[data-panel="' + tab + '"]');
+        if (!$panel.length || $panel.data('grid-loaded')) return;
+        $panel.data('grid-loaded', true);
+        populateIconGrid($panel.find('.vitrine-icons-grid'), tab);
+    }
+
     function isIconClass(icon) {
         return icon && (icon.indexOf('dashicons-') === 0 || /^fa[srlbd]?\s/.test(icon));
     }
@@ -121,17 +148,6 @@
             return '<i class="' + escapeAttr(icon) + '" style="font-size:26px;color:#0073aa;"></i>';
         }
         return '<img src="' + escapeAttr(icon) + '" style="max-width:48px;max-height:48px;border-radius:3px;object-fit:contain;display:block;" />';
-    }
-
-    function buildCanvasIconHtml(icon, size) {
-        if (!icon) return '';
-        if (icon.indexOf('dashicons-') === 0) {
-            return '<span class="dashicons ' + escapeAttr(icon) + '" style="font-size:' + size + 'px;width:' + size + 'px;height:' + size + 'px;color:inherit;flex-shrink:0;"></span>';
-        }
-        if (/^fa[srlbd]?\s/.test(icon)) {
-            return '<i class="' + escapeAttr(icon) + '" style="font-size:' + size + 'px;flex-shrink:0;"></i>';
-        }
-        return '<img src="' + escapeAttr(icon) + '" style="width:' + size + 'px;height:' + size + 'px;border-radius:3px;object-fit:contain;flex-shrink:0;" alt="" />';
     }
 
     /* ──────────────────── Helpers ──────────────────── */
@@ -219,6 +235,24 @@
             item.children = [];
         }
         return item;
+    }
+
+    function getContainerDisplayName(settings) {
+        var name = settings && settings.name ? String(settings.name).trim() : '';
+        return name || 'Container';
+    }
+
+    function getContainerPreviewLabel(settings) {
+        var dirLabel = (settings.direction === 'row') ? 'Linha (→)' : 'Coluna (↓)';
+        var cFull = settings.full_width_bg === '1' || settings.full_width_bg === 1;
+        return getContainerDisplayName(settings) + ' – ' + dirLabel + (cFull ? ' · Fundo largura total' : '');
+    }
+
+    function getBlockToolbarLabel(item, elDef) {
+        if (item.type === 'container') {
+            return getContainerDisplayName($.extend({}, elDef.defaults, item.settings));
+        }
+        return elDef.label;
     }
 
     /**
@@ -324,46 +358,6 @@
         renderSettings();
     }
 
-    /* ──────────────────── Hero Preview ──────────────────── */
-
-    function renderHeroPreview() {
-        var $prev = $('#vitrine-hero-preview');
-        var img   = pageSettings.hero_image || '';
-        var text  = pageSettings.hero_text || '';
-        var color = pageSettings.hero_text_color || '#ffffff';
-        var opa   = parseInt(pageSettings.hero_overlay_opacity || '50', 10) / 100;
-        var h     = parseInt(pageSettings.hero_height || '400', 10);
-        var fs    = parseInt(pageSettings.hero_font_size || '36', 10);
-        var align = pageSettings.hero_text_align || 'center';
-        var desc      = pageSettings.hero_description || '';
-        var dfs       = parseInt(pageSettings.hero_desc_size || '18', 10);
-        var textBold  = pageSettings.hero_text_bold !== '0' ? '700' : '400';
-        var textItal  = pageSettings.hero_text_italic === '1' ? 'italic' : 'normal';
-        var descBold  = '400'; // formatação inline no HTML
-        var descItal  = 'normal';
-
-        if (!img && !text && !desc) {
-            $prev.empty().hide();
-            return;
-        }
-
-        var justifyMap = { left: 'flex-start', center: 'center', right: 'flex-end' };
-        var justifyContent = justifyMap[align] || 'center';
-
-        var bgStyle = img ? 'background:url(' + escapeAttr(img) + ') center/cover no-repeat;' : 'background:#333;';
-        var html = '<div style="position:relative;' + bgStyle + 'height:' + h + 'px;border-radius:6px;overflow:hidden;display:flex;flex-direction:column;align-items:' + justifyContent + ';justify-content:center;gap:10px;margin-top:10px;padding:0 20px;">';
-        html += '<div style="position:absolute;inset:0;background:rgba(0,0,0,' + opa + ');"></div>';
-        if (text) {
-            html += '<span style="position:relative;z-index:1;font-size:' + fs + 'px;font-weight:' + textBold + ';font-style:' + textItal + ';color:' + escapeAttr(color) + ';text-align:' + escapeAttr(align) + ';text-shadow:0 2px 8px rgba(0,0,0,.5);">' + escapeHtml(text) + '</span>';
-        }
-        if (desc) {
-            html += '<span style="position:relative;z-index:1;font-size:' + dfs + 'px;color:' + escapeAttr(color) + ';text-align:' + escapeAttr(align) + ';opacity:0.9;text-shadow:0 1px 4px rgba(0,0,0,.5);">' + desc + '</span>';
-        }
-        html += '</div>';
-
-        $prev.html(html).show();
-    }
-
     /* ──────────────────── Renderização do Canvas ──────────────────── */
 
     function renderCanvas() {
@@ -437,7 +431,7 @@
                 '" data-id="' + item.id + '" data-type="' + item.type + '" style="' + heightStyle + widthStyle + blockBgStyle + escapeAttr(customCss) + '">' +
                     '<div class="vitrine-block-toolbar">' +
                         '<span class="vitrine-drag-handle dashicons dashicons-move"></span>' +
-                        '<span class="vitrine-block-label">' + escapeHtml(elDef.label) + '</span>' +
+                        '<span class="vitrine-block-label">' + escapeHtml(getBlockToolbarLabel(item, elDef)) + '</span>' +
                         widthBadgeHtml +
                         (isContainer ? (function() {
                             var dir = settings.direction || 'column';
@@ -488,180 +482,24 @@
         });
     }
 
-    /**
-     * Calcula linhas/colunas da Aranha Grade com imagem sempre no centro.
-     */
-    function frameGridSize(nItems) {
-        if (nItems <= 8) return 3;
-        var size = 5;
-        while (frameCapacity(size) < nItems) size += 2;
-        return Math.min(size, 15);
-    }
-
-    function frameCapacity(size) {
-        if (size <= 3) return 8;
-        return 4 * (size - 2);
-    }
-
-    function buildFramePools(rows, cols) {
-        var left = [], top = [], right = [], bottom = [];
-        if (rows === 3 && cols === 3) {
-            for (var c = 0; c < 3; c++) top.push([0, c]);
-            left.push([1, 0]);
-            right.push([1, 2]);
-            for (var c2 = 0; c2 < 3; c2++) bottom.push([2, c2]);
-            return { left: left, top: top, right: right, bottom: bottom };
-        }
-        for (var r = 1; r < rows - 1; r++) {
-            left.push([r, 0]);
-            right.push([r, cols - 1]);
-        }
-        for (var c3 = 1; c3 < cols - 1; c3++) {
-            top.push([0, c3]);
-            bottom.push([rows - 1, c3]);
-        }
-        return { left: left, top: top, right: right, bottom: bottom };
-    }
-
-    function distributeFrameCounts(n, maxL, maxT, maxR, maxB) {
-        var left = Math.min(maxL, n);
-        n -= left;
-        var top = Math.min(maxT, n);
-        n -= top;
-        var right = Math.min(maxR, n);
-        n -= right;
-        var bottom = Math.min(maxB, n);
-        n -= bottom;
-        if (n > 0) {
-            var add = Math.min(maxB - bottom, n);
-            bottom += add;
-            n -= add;
-            top = Math.min(maxT, top + n);
-        }
-        return { left: left, top: top, right: Math.max(0, right), bottom: Math.max(0, bottom) };
-    }
-
-    function assignAranha3Groups(items, max) {
-        var groups = { left: [], top: [], right: [], bottom: [] };
-        var autoItems = [];
-        var allowed = ['top', 'bottom', 'left', 'right'];
-
-        items.forEach(function (it) {
-            var pos = it.position || 'auto';
-            if (allowed.indexOf(pos) !== -1 && groups[pos].length < max[pos]) {
-                groups[pos].push(it);
-            } else {
-                autoItems.push(it);
-            }
-        });
-
-        if (!autoItems.length) return groups;
-
-        var remainMax = {
-            left: Math.max(0, max.left - groups.left.length),
-            top: Math.max(0, max.top - groups.top.length),
-            right: Math.max(0, max.right - groups.right.length),
-            bottom: Math.max(0, max.bottom - groups.bottom.length)
-        };
-        var counts = distributeFrameCounts(
-            autoItems.length, remainMax.left, remainMax.top, remainMax.right, remainMax.bottom
-        );
-        var order = ['left', 'top', 'right', 'bottom'];
-        var offset = 0;
-        order.forEach(function (side) {
-            var take = counts[side];
-            if (take > 0) {
-                groups[side] = groups[side].concat(autoItems.slice(offset, offset + take));
-                offset += take;
-            }
-        });
-        return groups;
-    }
-
-    function computeAranha3Groups(items, preferredCols) {
-        var n = items.length;
-        var empty = { left: [], top: [], right: [], bottom: [] };
-        if (n <= 0) return { groups: empty };
-        if (n === 1) return { groups: { left: [items[0]], top: [], right: [], bottom: [] } };
-        if (n === 2) return { groups: { left: [items[0]], top: [], right: [items[1]], bottom: [] } };
-
-        var size = frameGridSize(n);
-        var pools = buildFramePools(size, size);
-        var max = {
-            left: pools.left.length,
-            top: pools.top.length,
-            right: pools.right.length,
-            bottom: pools.bottom.length
-        };
-        return { groups: assignAranha3Groups(items, max) };
-    }
-
-    function buildA3BoxShadow(intensity) {
-        var i = Math.max(0, Math.min(100, parseInt(intensity, 10) || 0));
-        if (i <= 0) return 'none';
-        var y = Math.max(1, Math.round(i * 0.08));
-        var blur = Math.max(2, Math.round(i * 0.32));
-        var alpha = (i * 0.0012).toFixed(3);
-        return '0 ' + y + 'px ' + blur + 'px rgba(0,0,0,' + alpha + ')';
-    }
-
-    function buildA3HexRgba(hex, opacityPct) {
-        hex = String(hex || '#d0d8c4').replace('#', '');
-        if (hex.length === 3) {
-            hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-        }
-        var r = parseInt(hex.substr(0, 2), 16) || 208;
-        var g = parseInt(hex.substr(2, 2), 16) || 216;
-        var b = parseInt(hex.substr(4, 2), 16) || 196;
-        var a = Math.max(0, Math.min(100, parseInt(opacityPct, 10) || 0)) / 100;
-        return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
-    }
-
-    function buildA3FlexAlign(align) {
-        if (align === 'center') return 'center';
-        if (align === 'bottom') return 'flex-end';
-        return 'flex-start';
-    }
-
-    function buildA3CardBorderCss(settings) {
-        var style = settings.card_border_style || 'none';
-        var allowed = ['none', 'solid', 'dashed', 'dotted', 'double'];
-        if (allowed.indexOf(style) === -1) style = 'none';
-        var width = Math.max(0, Math.min(20, parseInt(settings.card_border_width || 0, 10)));
-        var color = escapeAttr(settings.card_border_color || '#d0d0d0');
-        if (style === 'none' || width <= 0) return 'border:none;';
-        return 'border:' + width + 'px ' + style + ' ' + color + ';';
-    }
-
-    function buildA3PreviewCard(a3It, a3CrdBg, a3Rad, a3BorderCss, a3TitCl, a3TxtCl, a3IcSz, a3CardH, a3Side, a3Shadow, a3Align) {
-        var cardStyle = 'background:' + a3CrdBg + ';border-radius:' + a3Rad + 'px;' + a3BorderCss + 'padding:8px 10px;box-sizing:border-box;box-shadow:' + a3Shadow + ';display:flex;flex-direction:column;justify-content:' + a3Align + ';min-height:' + a3CardH + 'px;height:auto;';
-        if (a3Side) {
-            cardStyle += 'flex:0 1 auto;width:100%;';
-        } else {
-            cardStyle += 'flex:1 1 0;min-width:80px;';
-        }
-        var h = '<div style="' + cardStyle + '">';
-        h += '<div style="display:flex;align-items:flex-start;gap:6px;">';
-        if (a3It.icon) h += '<div style="flex-shrink:0;">' + buildCanvasIconHtml(a3It.icon, a3IcSz) + '</div>';
-        h += '<div style="flex:1;min-width:0;">';
-        if (a3It.title) h += '<div style="font-weight:700;font-size:9px;color:' + a3TitCl + ';margin-bottom:2px;line-height:1.3;">' + escapeHtml(a3It.title) + '</div>';
-        if (a3It.text)  h += '<div style="font-size:8px;color:' + a3TxtCl + ';line-height:1.4;">' + (a3It.text || '') + '</div>';
-        h += '</div></div></div>';
-        return h;
-    }
-
-    function buildA3PreviewGroup(groupItems, a3CrdBg, a3Rad, a3BorderCss, a3TitCl, a3TxtCl, a3IcSz, a3CardH, a3Side, a3Shadow, a3Align) {
-        var h = '';
-        groupItems.forEach(function (it) {
-            h += buildA3PreviewCard(it, a3CrdBg, a3Rad, a3BorderCss, a3TitCl, a3TxtCl, a3IcSz, a3CardH, a3Side, a3Shadow, a3Align);
-        });
-        return h;
+    function buildAranhaEditorPlaceholder(type) {
+        var icons = { aranha: 'dashicons-networking', aranha2: 'dashicons-chart-pie', aranha3: 'dashicons-grid-view' };
+        var labels = { aranha: 'Aranha', aranha2: 'Aranha Circular', aranha3: 'Aranha Grade' };
+        return '<div class="vitrine-block-preview-placeholder vitrine-block-preview-placeholder--aranha">' +
+            '<span class="dashicons ' + (icons[type] || 'dashicons-layout') + '"></span>' +
+            '<span class="vitrine-block-preview-placeholder__label">' + escapeHtml(labels[type] || type) + '</span>' +
+            '<small>Configure no painel lateral · visualização no frontend</small>' +
+        '</div>';
     }
 
     /**
      * Preview simplificado de cada tipo de elemento dentro do canvas.
      */
     function buildPreview(type, settings) {
+        if (type === 'aranha' || type === 'aranha2' || type === 'aranha3') {
+            return buildAranhaEditorPlaceholder(type);
+        }
+
         switch (type) {
             case 'title':
                 var tag = settings.tag || 'h2';
@@ -703,7 +541,6 @@
                 return tiHtml;
             }
             case 'imagelinks': {
-                var ilItems   = settings.items || [];
                 var ilImgH    = Math.max(60, Math.min(280, parseInt(settings.image_height || 220, 10)));
                 var ilImgFit  = settings.image_fit === 'contain' ? 'contain' : 'cover';
                 var ilCapBg   = escapeAttr(settings.caption_bg || '#000000');
@@ -714,8 +551,9 @@
                 var ilBoxTit  = settings.box_title || '';
                 var ilTitCl   = escapeAttr(settings.box_title_color || '#333333');
                 var ilTitSz   = parseInt(settings.box_title_font_size || 16, 10);
-                var ilLinkCl  = escapeAttr(settings.link_color || '#333333');
-                var ilLinkSz  = parseInt(settings.link_font_size || 14, 10);
+                var ilContent = getImagelinksContent(settings);
+                var ilTextCl  = escapeAttr(settings.content_color || settings.link_color || '#333333');
+                var ilTextSz  = parseInt(settings.content_font_size || settings.link_font_size || 14, 10);
                 var ilSepCl   = escapeAttr(settings.separator_color || '#333333');
                 var ilPad     = parseInt(settings.box_padding || 16, 10);
 
@@ -730,23 +568,20 @@
                 if (ilCap) {
                     ilHtml += '<div style="background:' + ilCapBg + ';color:' + ilCapCl + ';font-size:' + ilCapSz + 'px;font-weight:700;text-align:center;padding:8px 10px;line-height:1.3;">' + escapeHtml(ilCap) + '</div>';
                 }
-                ilHtml += '<div style="background:' + ilBoxBg + ';padding:' + ilPad + 'px;">';
-                if (ilBoxTit) {
-                    ilHtml += '<div style="color:' + ilTitCl + ';font-size:' + ilTitSz + 'px;font-weight:700;margin:0 0 8px;line-height:1.3;">' + escapeHtml(ilBoxTit) + '</div>';
+                if (ilBoxTit || ilContent) {
+                    ilHtml += '<div style="background:' + ilBoxBg + ';padding:' + ilPad + 'px;">';
+                    if (ilBoxTit) {
+                        ilHtml += '<div style="color:' + ilTitCl + ';font-size:' + ilTitSz + 'px;font-weight:700;margin:0 0 8px;line-height:1.3;">' + escapeHtml(ilBoxTit) + '</div>';
+                    }
+                    if (ilBoxTit && ilContent) {
+                        ilHtml += '<hr style="border:none;border-top:1px solid ' + ilSepCl + ';margin:0 0 8px;" />';
+                    }
+                    if (ilContent) {
+                        ilHtml += '<div style="color:' + ilTextCl + ';font-size:' + ilTextSz + 'px;line-height:1.5;">' + ilContent + '</div>';
+                    }
+                    ilHtml += '</div>';
                 }
-                ilHtml += '<hr style="border:none;border-top:1px solid ' + ilSepCl + ';margin:0 0 8px;" />';
-                ilHtml += '<ul style="list-style:none;margin:0;padding:0;">';
-                if (ilItems.length) {
-                    ilItems.forEach(function (li) {
-                        if (!li.label) return;
-                        ilHtml += '<li style="margin:0 0 5px;line-height:1.4;">';
-                        ilHtml += '<span style="color:' + ilLinkCl + ';font-size:' + ilLinkSz + 'px;text-decoration:underline;">' + escapeHtml(li.label) + '</span>';
-                        ilHtml += '</li>';
-                    });
-                } else {
-                    ilHtml += '<li style="color:#999;font-size:10px;">Adicione links no painel</li>';
-                }
-                ilHtml += '</ul></div></div>';
+                ilHtml += '</div>';
                 return ilHtml;
             }
             case 'image':
@@ -768,126 +603,16 @@
                     + '</div>';
             }
             case 'container':
-                var dirLabel = (settings.direction === 'row') ? 'Linha (→)' : 'Coluna (↓)';
                 var cBg = 'background-color:' + escapeAttr(settings.bg_color || '#f5f5f5') + ';';
                 if (settings.bg_image) {
                     cBg += 'background-image:url(' + escapeAttr(settings.bg_image) + ');background-size:' + escapeAttr(settings.bg_size || 'cover') + ';background-position:center;';
                 }
                 var cFull = settings.full_width_bg === '1' || settings.full_width_bg === 1;
-                var cLabel = 'Container – ' + dirLabel + (cFull ? ' · Fundo largura total' : '');
+                var cLabel = getContainerPreviewLabel(settings);
                 if (cFull) {
                     return '<div style="' + cBg + 'padding:6px 0;margin:0 -8px;"><div style="max-width:' + parseInt(settings.max_width || 1200, 10) + 'px;margin:0 auto;padding:0 8px;"><div class="vitrine-container-label" style="padding:4px 10px;font-size:11px;color:#666;">' + escapeHtml(cLabel) + '</div></div></div>';
                 }
                 return '<div class="vitrine-container-label" style="' + cBg + 'padding:4px 10px;font-size:11px;color:#666;border-radius:3px 3px 0 0;">' + escapeHtml(cLabel) + '</div>';
-            case 'aranha':
-                var leftItems = settings.left_items || [];
-                var rightItems = settings.right_items || [];
-                var topItems = settings.top_items || [];
-                var aLineColor = escapeAttr(settings.line_color || '#2e7d32');
-                var aTextColor = escapeAttr(settings.text_color || '#333');
-                var aIconSize = Math.min(parseInt(settings.icon_size || 40, 10), 28);
-
-                var aMaxItems = Math.max(leftItems.length, rightItems.length, 1);
-                var aCenterSize = Math.min(Math.max(70, aMaxItems * 32), 500);
-
-                var aCenterBg = escapeAttr(settings.center_bg_color || '#e0e0e0');
-                var aCenterImg = settings.center_image
-                    ? '<img src="' + escapeAttr(settings.center_image) + '" style="width:100%;height:100%;border-radius:50%;object-fit:cover;border:3px solid ' + aLineColor + ';background:' + aCenterBg + ';" alt="" />'
-                    : '<div style="width:100%;height:100%;border-radius:50%;background:' + aCenterBg + ';border:3px solid ' + aLineColor + ';"></div>';
-
-                function buildAranhaArm(bend, side, color) {
-                    var overlap = side === 'left' ? 'margin-right:-20px;' : 'margin-left:-20px;';
-                    var base = 'flex:1;min-width:10px;position:relative;align-self:stretch;overflow:visible;' + overlap + 'z-index:1;';
-                    var d;
-                    if (side === 'left') {
-                        if (bend === 'straight')    d = 'M 0,50 L 100,50';
-                        else if (bend === 'down')   d = 'M 0,50 C 50,50 50,100 100,100';
-                        else                        d = 'M 0,50 C 50,50 50,0 100,0';
-                    } else {
-                        if (bend === 'straight')    d = 'M 100,50 L 0,50';
-                        else if (bend === 'down')   d = 'M 100,50 C 50,50 50,100 0,100';
-                        else                        d = 'M 100,50 C 50,50 50,0 0,0';
-                    }
-                    return '<div style="' + base + '">' +
-                        '<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none" style="overflow:visible;">' +
-                        '<path d="' + d + '" fill="none" stroke="' + color + '" stroke-width="2" vector-effect="non-scaling-stroke" stroke-linecap="round" /></svg>' +
-                    '</div>';
-                }
-
-                function buildAranhaCards(items, side) {
-                    if (!items.length) return '<div style="flex:1;"></div>';
-                    var n = items.length;
-                    var mid = (n - 1) / 2;
-                    var h = '<div style="flex:1;display:flex;flex-direction:column;justify-content:center;position:relative;">';
-                    items.forEach(function (ai, idx) {
-                        var t = ai.text || '';
-                        var ic = ai.icon || '';
-                        var bend;
-                        if (n <= 1 || Math.abs(idx - mid) < 0.1) { bend = 'straight'; }
-                        else if (idx < mid) { bend = 'down'; }
-                        else { bend = 'up'; }
-
-                        h += '<div style="flex:1;display:flex;align-items:center;padding:4px 0;">';
-                        if (side === 'left') {
-                            h += '<div style="display:flex;align-items:center;gap:6px;border:2px solid ' + aLineColor + ';border-radius:8px;padding:6px 10px;background:#fff;flex-shrink:0;max-width:180px;position:relative;z-index:2;">';
-                            h += '<span style="font-size:11px;color:' + aTextColor + ';text-align:right;line-height:1.3;">' + (t || '') + '</span>';
-                            if (ic) h += buildCanvasIconHtml(ic, aIconSize);
-                            h += '</div>';
-                            h += buildAranhaArm(bend, side, aLineColor);
-                        } else {
-                            h += buildAranhaArm(bend, side, aLineColor);
-                            h += '<div style="display:flex;align-items:center;gap:6px;border:2px solid ' + aLineColor + ';border-radius:8px;padding:6px 10px;background:#fff;flex-shrink:0;max-width:180px;position:relative;z-index:2;">';
-                            if (ic) h += buildCanvasIconHtml(ic, aIconSize);
-                            h += '<span style="font-size:11px;color:' + aTextColor + ';line-height:1.3;">' + (t || '') + '</span>';
-                            h += '</div>';
-                        }
-                        h += '</div>';
-                    });
-                    h += '</div>';
-                    return h;
-                }
-
-                function buildAranhaTopCards(items) {
-                    if (!items.length) return '';
-                    var n = items.length;
-                    var mid = (n - 1) / 2;
-                    var h = '<div style="display:flex;justify-content:center;gap:0;">';
-                    items.forEach(function (ai, idx) {
-                        var t = ai.text || '';
-                        var ic = ai.icon || '';
-                        var bend;
-                        if (n <= 1 || Math.abs(idx - mid) < 0.1) { bend = 'straight'; }
-                        else if (idx < mid) { bend = 'left'; }
-                        else { bend = 'right'; }
-
-                        h += '<div style="flex:1;display:flex;flex-direction:column;align-items:center;">';
-                        h += '<div style="display:flex;align-items:center;gap:6px;border:2px solid ' + aLineColor + ';border-radius:8px;padding:6px 10px;background:#fff;flex-shrink:0;max-width:180px;position:relative;z-index:2;">';
-                        if (ic) h += buildCanvasIconHtml(ic, aIconSize);
-                        h += '<span style="font-size:11px;color:' + aTextColor + ';line-height:1.3;text-align:center;">' + (t || '') + '</span>';
-                        h += '</div>';
-                        // Vertical arm — SVG Bézier
-                        var ad;
-                        if (bend === 'straight')    ad = 'M 50,0 L 50,100';
-                        else if (bend === 'left')   ad = 'M 50,0 C 50,50 100,50 100,100';
-                        else                        ad = 'M 50,0 C 50,50 0,50 0,100';
-                        h += '<div style="flex:1;min-height:20px;width:100%;position:relative;margin-bottom:-20px;z-index:1;overflow:visible;">' +
-                            '<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none" style="overflow:visible;">' +
-                            '<path d="' + ad + '" fill="none" stroke="' + aLineColor + '" stroke-width="2" vector-effect="non-scaling-stroke" stroke-linecap="round" /></svg>' +
-                        '</div>';
-                        h += '</div>';
-                    });
-                    h += '</div>';
-                    return h;
-                }
-
-                return (topItems.length ? buildAranhaTopCards(topItems) : '') +
-                    '<div style="display:flex;align-items:stretch;gap:0;min-height:120px;">' +
-                    buildAranhaCards(leftItems, 'left') +
-                    '<div style="display:flex;align-items:center;justify-content:center;position:relative;flex-shrink:0;z-index:3;width:' + aCenterSize + 'px;min-height:' + aCenterSize + 'px;max-width:500px;max-height:500px;aspect-ratio:1;">' +
-                        aCenterImg +
-                    '</div>' +
-                    buildAranhaCards(rightItems, 'right') +
-                '</div>';
             case 'toggle':
                 var tItems = settings.items || [];
                 if (!tItems.length) {
@@ -919,128 +644,6 @@
                     return '<div style="text-align:center;color:#d63638;font-size:12px;">URL do YouTube inv\u00e1lida</div>';
                 }
                 return '<div style="text-align:center;padding:8px;"><video src="' + escapeAttr(vUrl) + '" style="max-width:100%;max-height:120px;border-radius:4px;" muted></video><div style="font-size:11px;color:#666;margin-top:4px;">V\u00eddeo local</div></div>';
-            case 'aranha2':
-                var a2Items  = settings.items || [];
-                var a2N      = Math.max(1, a2Items.length);
-                var a2Radius = Math.min(parseInt(settings.radius || 200, 10), 180);
-                var a2CSize  = Math.min(parseInt(settings.center_size || 160, 10), 90);
-                var a2Over   = 70;
-                var a2Stage  = a2CSize + 2 * a2Radius + 2 * a2Over;
-                var a2Cx     = a2Stage / 2;
-                var a2Cy     = a2Stage / 2;
-                var a2Rp     = a2Radius / a2Stage * 100;
-                var a2Cp     = a2CSize  / a2Stage * 100;
-                var a2Line   = escapeAttr(settings.line_color   || '#2e7d32');
-                var a2CBg    = escapeAttr(settings.center_bg_color || '#e0e0e0');
-                var a2CrdBg  = escapeAttr(settings.card_bg      || '#ffffff');
-                var a2CrdBdr = escapeAttr(settings.card_border  || '#2e7d32');
-                var a2Txt    = escapeAttr(settings.text_color   || '#1d2327');
-                var a2IcSz   = Math.min(parseInt(settings.icon_size || 36, 10), 20);
-                var a2Bg     = escapeAttr(settings.bg_color     || '#f8f9fa');
-
-                var a2Html = '<div style="background:' + a2Bg + ';padding:12px;border-radius:4px;">';
-                a2Html += '<div style="position:relative;width:' + a2Stage + 'px;height:' + a2Stage + 'px;max-width:100%;margin:0 auto;">';
-
-                // SVG lines
-                a2Html += '<svg style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:visible;" viewBox="0 0 ' + a2Stage + ' ' + a2Stage + '">';
-                a2Items.forEach(function (ai, i) {
-                    var ang  = -Math.PI / 2 + i * (2 * Math.PI / a2N);
-                    var px   = a2Cx + a2Radius * Math.cos(ang);
-                    var py   = a2Cy + a2Radius * Math.sin(ang);
-                    var dx   = px - a2Cx, dy = py - a2Cy;
-                    var len  = Math.sqrt(dx * dx + dy * dy) || 1;
-                    var mx   = (a2Cx + px) / 2, my = (a2Cy + py) / 2;
-                    var curv = a2Radius * 0.22;
-                    var cx2  = mx + curv * (-dy / len);
-                    var cy2  = my + curv * ( dx / len);
-                    a2Html += '<path d="M ' + a2Cx.toFixed(1) + ',' + a2Cy.toFixed(1) + ' Q ' + cx2.toFixed(1) + ',' + cy2.toFixed(1) + ' ' + px.toFixed(1) + ',' + py.toFixed(1) + '" fill="none" stroke="' + a2Line + '" stroke-width="1.4" stroke-linecap="round" opacity="0.7"/>';
-                    a2Html += '<circle cx="' + px.toFixed(1) + '" cy="' + py.toFixed(1) + '" r="3" fill="' + a2Line + '"/>';
-                });
-                a2Html += '</svg>';
-
-                // Center
-                a2Html += '<div style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:' + a2CSize + 'px;height:' + a2CSize + 'px;border-radius:50%;background:' + a2CBg + ';border:3px solid ' + a2Line + ';overflow:hidden;z-index:3;box-shadow:0 2px 10px rgba(0,0,0,.12);">';
-                if (settings.center_image) {
-                    a2Html += '<img src="' + escapeAttr(settings.center_image) + '" style="width:100%;height:100%;object-fit:cover;" />';
-                }
-                a2Html += '</div>';
-
-                // Cards
-                a2Items.forEach(function (ai, i) {
-                    var ang = -Math.PI / 2 + i * (2 * Math.PI / a2N);
-                    var px  = a2Cx + a2Radius * Math.cos(ang);
-                    var py  = a2Cy + a2Radius * Math.sin(ang);
-                    a2Html += '<div style="position:absolute;left:' + px.toFixed(1) + 'px;top:' + py.toFixed(1) + 'px;transform:translate(-50%,-50%);background:' + a2CrdBg + ';border:1.5px solid ' + a2CrdBdr + ';border-radius:10px;padding:6px 9px;font-size:10px;color:' + a2Txt + ';text-align:center;min-width:52px;max-width:85px;z-index:4;display:flex;flex-direction:column;align-items:center;gap:3px;box-shadow:0 2px 8px rgba(0,0,0,.08);">';
-                    if (ai.icon) a2Html += buildCanvasIconHtml(ai.icon, a2IcSz);
-                    if (ai.text) a2Html += '<span style="font-size:9px;font-weight:600;line-height:1.2;">' + escapeHtml(ai.text) + '</span>';
-                    a2Html += '</div>';
-                });
-
-                if (!a2Items.length) {
-                    a2Html += '<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#a7aaad;font-size:11px;text-align:center;padding:20px;z-index:4;">Adicione itens no painel</div>';
-                }
-
-                a2Html += '</div></div>';
-                return a2Html;
-
-            case 'aranha3': {
-                var a3Items   = settings.items || [];
-                var a3PrefCol = parseInt(settings.columns || 3, 10);
-                var a3Groups  = computeAranha3Groups(a3Items, a3PrefCol).groups;
-                var a3Bg      = escapeAttr(settings.bg_color    || '#f4f4f2');
-                var a3CrdBg   = escapeAttr(settings.card_bg     || '#ffffff');
-                var a3TitCl   = escapeAttr(settings.title_color || '#2c3a1a');
-                var a3TxtCl   = escapeAttr(settings.text_color  || '#555555');
-                var a3CardRad = Math.min(parseInt(settings.card_border_radius !== undefined ? settings.card_border_radius : (settings.border_radius || 12), 10), 10);
-                var a3ImgRad  = Math.min(parseInt(settings.image_border_radius !== undefined ? settings.image_border_radius : (settings.border_radius || 12), 10), 10);
-                var a3Gap     = Math.min(parseInt(settings.gap || 16, 10), 8);
-                var a3IcSz    = Math.min(parseInt(settings.icon_size || 32, 10), 18);
-                var a3CardH   = Math.max(60, Math.min(parseInt(settings.card_height || 140, 10), 72));
-                var a3CrdSh   = buildA3BoxShadow(settings.card_shadow !== undefined ? settings.card_shadow : 6);
-                var a3ImgSh   = buildA3BoxShadow(settings.image_shadow || 0);
-                var a3ImgBg   = buildA3HexRgba(settings.center_bg_color || '#d0d8c4', settings.center_bg_opacity !== undefined ? settings.center_bg_opacity : 100);
-                var a3Align   = buildA3FlexAlign(settings.card_text_align || 'top');
-                var a3Border  = buildA3CardBorderCss(settings);
-                var a3ImgSz   = Math.max(80, Math.min(300, parseInt(settings.center_size || 240, 10)));
-                var a3ImgFit  = settings.center_image_fit === 'contain' ? 'contain' : 'cover';
-
-                var a3Img = '<div style="border-radius:' + a3ImgRad + 'px;overflow:hidden;height:' + a3ImgSz + 'px;min-height:' + a3ImgSz + 'px;max-height:' + a3ImgSz + 'px;flex:0 0 auto;width:100%;background:' + a3ImgBg + ';box-shadow:' + a3ImgSh + ';">';
-                if (settings.center_image) {
-                    a3Img += '<img src="' + escapeAttr(settings.center_image) + '" style="width:100%;height:100%;object-fit:' + a3ImgFit + ';object-position:center;display:block;" />';
-                } else {
-                    a3Img += '<div style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:#8a9e78;font-size:9px;font-weight:700;">IMAGEM</div>';
-                }
-                a3Img += '</div>';
-
-                var a3Html = '<div style="padding:12px;background:' + a3Bg + ';border-radius:6px;">';
-
-                if (a3Items.length <= 2) {
-                    a3Html += '<div style="display:flex;align-items:flex-start;gap:' + a3Gap + 'px;">';
-                    a3Html += buildA3PreviewGroup(a3Groups.left, a3CrdBg, a3CardRad, a3Border, a3TitCl, a3TxtCl, a3IcSz, a3CardH, true, a3CrdSh, a3Align);
-                    a3Html += a3Img;
-                    a3Html += buildA3PreviewGroup(a3Groups.right, a3CrdBg, a3CardRad, a3Border, a3TitCl, a3TxtCl, a3IcSz, a3CardH, true, a3CrdSh, a3Align);
-                    a3Html += '</div>';
-                } else {
-                    a3Html += '<div style="display:grid;grid-template-columns:minmax(90px,1fr) minmax(80px,320px) minmax(90px,1fr);grid-template-rows:auto auto auto;align-items:center;gap:' + a3Gap + 'px;">';
-                    a3Html += '<div style="grid-column:1/-1;grid-row:1;display:flex;gap:' + a3Gap + 'px;justify-content:center;">';
-                    a3Html += buildA3PreviewGroup(a3Groups.top, a3CrdBg, a3CardRad, a3Border, a3TitCl, a3TxtCl, a3IcSz, a3CardH, false, a3CrdSh, a3Align);
-                    a3Html += '</div>';
-                    a3Html += '<div style="grid-column:1;grid-row:2;display:flex;flex-direction:column;gap:' + a3Gap + 'px;align-self:center;width:100%;min-width:0;">';
-                    a3Html += buildA3PreviewGroup(a3Groups.left, a3CrdBg, a3CardRad, a3Border, a3TitCl, a3TxtCl, a3IcSz, a3CardH, true, a3CrdSh, a3Align);
-                    a3Html += '</div>';
-                    a3Html += '<div style="grid-column:2;grid-row:2;width:100%;max-width:320px;justify-self:center;margin:0 auto;">' + a3Img + '</div>';
-                    a3Html += '<div style="grid-column:3;grid-row:2;display:flex;flex-direction:column;gap:' + a3Gap + 'px;align-self:center;width:100%;min-width:0;">';
-                    a3Html += buildA3PreviewGroup(a3Groups.right, a3CrdBg, a3CardRad, a3Border, a3TitCl, a3TxtCl, a3IcSz, a3CardH, true, a3CrdSh, a3Align);
-                    a3Html += '</div>';
-                    a3Html += '<div style="grid-column:1/-1;grid-row:3;display:flex;gap:' + a3Gap + 'px;justify-content:center;">';
-                    a3Html += buildA3PreviewGroup(a3Groups.bottom, a3CrdBg, a3CardRad, a3Border, a3TitCl, a3TxtCl, a3IcSz, a3CardH, false, a3CrdSh, a3Align);
-                    a3Html += '</div>';
-                    a3Html += '</div>';
-                }
-
-                a3Html += '</div>';
-                return a3Html;
-            }
 
             default:
                 return '<p>' + escapeHtml(type) + '</p>';
@@ -1055,6 +658,30 @@
 
     function escapeAttr(str) {
         return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function safeTextareaHtml(str) {
+        return String(str || '').replace(/<\/textarea/gi, '&lt;/textarea');
+    }
+
+    function getImagelinksContent(settings) {
+        if (settings.content) {
+            return settings.content;
+        }
+        var items = settings.items || [];
+        if (!items.length) {
+            return '';
+        }
+        var html = '';
+        items.forEach(function (li) {
+            if (!li.label) return;
+            if (li.url) {
+                html += '<p style="margin:0 0 6px;line-height:1.45;"><a href="' + escapeAttr(li.url) + '">' + escapeHtml(li.label) + '</a></p>';
+            } else {
+                html += '<p style="margin:0 0 6px;line-height:1.45;">' + escapeHtml(li.label) + '</p>';
+            }
+        });
+        return html;
     }
 
     /* ──────────────────── Sortable (drag & drop) ──────────────────── */
@@ -1396,6 +1023,8 @@
     /* ──────────────────── Sidebar de Configurações ──────────────────── */
 
     function renderSettings() {
+        syncAllAranhaMCE();
+        syncAllFieldMCE();
         destroyAllMCE();
         var $panel = $('#vitrine-settings-panel');
         $panel.empty();
@@ -1421,7 +1050,10 @@
 
         // Atualiza cabeçalho da sidebar com ícone e nome do elemento
         $('#vitrine-settings-el-icon').attr('class', 'dashicons ' + (elDef.icon || 'dashicons-admin-settings'));
-        $('#vitrine-settings-el-label').text(elDef.label || 'Configurações');
+        var settingsHeaderLabel = item.type === 'container'
+            ? getContainerDisplayName($.extend({}, elDef.defaults, item.settings))
+            : (elDef.label || 'Configurações');
+        $('#vitrine-settings-el-label').text(settingsHeaderLabel);
         $('#vitrine-settings-sidebar').addClass('has-selection');
 
         var fields = elDef.fields;
@@ -1453,7 +1085,10 @@
 
             switch (field.type) {
                 case 'textarea':
-                    inputHtml = '<textarea id="vitrine-field-mce-' + escapeAttr(field.name) + '" class="vitrine-field-mce" data-field="' + escapeAttr(field.name) + '" rows="4">' + escapeHtml(val) + '</textarea>';
+                    inputHtml = '<textarea id="vitrine-field-mce-' + escapeAttr(field.name) + '" class="vitrine-field-mce" data-field="' + escapeAttr(field.name) + '" rows="4">' + safeTextareaHtml(val) + '</textarea>';
+                    if (item.type === 'imagelinks' && field.name === 'content') {
+                        inputHtml += '<p class="vitrine-field-hint">Editor livre abaixo da imagem — negrito, itálico, links, listas etc.</p>';
+                    }
                     break;
                 case 'plaintextarea':
                     inputHtml = '<textarea class="vitrine-field vitrine-field-plaintextarea" data-field="' + escapeAttr(field.name) + '" rows="5" spellcheck="false" placeholder="[meu_shortcode attr=&quot;valor&quot;]">' + escapeHtml(val) + '</textarea>';
@@ -1502,16 +1137,26 @@
             }
 
             var extraClass = (field.type === 'textarea' || field.type === 'image') ? ' vitrine-field-group--full' : '';
+            var fieldHint = '';
+            if (item.type === 'container' && field.name === 'name') {
+                fieldHint = '<p class="vitrine-field-hint">Aparece na barra do bloco no canvas para identificar cada container.</p>';
+            }
             $panel.append(
                 '<div class="vitrine-field-group' + extraClass + '">' +
                     '<label>' + escapeHtml(field.label) + '</label>' +
                     inputHtml +
+                    fieldHint +
                 '</div>'
             );
         });
 
         // ── Aranha: seções de itens dinâmicos ──
         if (item.type === 'aranha') {
+            $panel.append(
+                '<p class="vitrine-field-hint vitrine-aranha-drag-hint" style="margin:0 0 10px;">' +
+                'Arraste os itens entre <strong>Esquerda</strong>, <strong>Direita</strong> e <strong>Topo</strong> para mudar a posição no layout.' +
+                '</p>'
+            );
             renderAranhaRepeater($panel, item, 'left_items', 'Itens da Esquerda');
             renderAranhaRepeater($panel, item, 'right_items', 'Itens da Direita');
             renderAranhaRepeater($panel, item, 'top_items', 'Itens do Topo');
@@ -1532,11 +1177,6 @@
             renderToggleRepeater($panel, item);
         }
 
-        // ── Imagem + Links: repeater de links ──
-        if (item.type === 'imagelinks') {
-            renderImagelinksRepeater($panel, item);
-        }
-
         // ── CSS Personalizado (todos os elementos) ──
         var customCss = item.settings.custom_css || '';
         $panel.append(
@@ -1548,19 +1188,9 @@
             '</div>'
         );
 
-        // Inicializa TinyMCE nos campos de texto da aranha
-        if (item.type === 'aranha') {
+        // Inicializa TinyMCE e drag-sort nos itens das aranhas
+        if (item.type === 'aranha' || item.type === 'aranha2' || item.type === 'aranha3') {
             setTimeout(initAranhaMCE, 50);
-            setTimeout(initAranhaSort, 80);
-        }
-
-        // Aranha2: só sorting (sem MCE — usa inputs simples)
-        if (item.type === 'aranha2') {
-            setTimeout(initAranhaSort, 80);
-        }
-
-        // Aranha3: só sorting (sem MCE)
-        if (item.type === 'aranha3') {
             setTimeout(initAranhaSort, 80);
         }
 
@@ -1606,47 +1236,75 @@
         $panel.append(html);
     }
 
-    /**
-     * Renderiza a seção de links do elemento Imagem + Links.
-     */
-    function renderImagelinksRepeater($panel, item) {
-        if (!item.settings.items || !Array.isArray(item.settings.items)) {
-            item.settings.items = [];
-        }
-        var items = item.settings.items;
-
-        var html = '<div class="vitrine-imagelinks-section">';
-        html += '<hr style="border:none;border-top:1px solid #dcdcde;margin:14px 0 10px;" />';
-        html += '<h4 class="vitrine-repeater-section-title">Links (' + items.length + ')</h4>';
-        html += '<p style="margin:0 0 10px;font-size:11px;color:#8c8f94;line-height:1.5;">Lista de sites relacionados exibida abaixo da imagem.</p>';
-        html += '<div class="vitrine-imagelinks-items-list">';
-
-        items.forEach(function (li, idx) {
-            html += '<div class="vitrine-repeater-item vitrine-imagelinks-editor-item" data-imagelinks-idx="' + idx + '">';
-            html += '<div class="vitrine-repeater-item-header">';
-            html += '<span class="vitrine-repeater-item-num">' + (idx + 1) + '</span>';
-            html += '<span style="font-size:11px;color:#646970;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:0 8px;">' + escapeHtml(li.label || 'Link ' + (idx + 1)) + '</span>';
-            html += '<button type="button" class="button button-small vitrine-imagelinks-remove-item" title="Remover">&times;</button>';
-            html += '</div>';
-            html += '<div class="vitrine-field-group"><label>Texto do link</label>';
-            html += '<input type="text" class="vitrine-imagelinks-field" data-imagelinks-prop="label" value="' + escapeAttr(li.label || '') + '" placeholder="Ex: Ministério da Saúde" /></div>';
-            html += '<div class="vitrine-field-group"><label>URL</label>';
-            html += '<input type="text" class="vitrine-imagelinks-field" data-imagelinks-prop="url" value="' + escapeAttr(li.url || '') + '" placeholder="https://..." /></div>';
-            html += '</div>';
-        });
-
-        html += '</div>';
-        html += '<button type="button" class="button vitrine-imagelinks-add-item" style="width:100%;margin-top:8px;">+ Adicionar Link</button>';
-        html += '</div>';
-
-        $panel.append(html);
-    }
-
     /* ── TinyMCE helpers ── */
 
     var _skipMCESync = false;
+    var aranhaSortInstances = [];
+
+    function destroyAranhaSort() {
+        aranhaSortInstances.forEach(function (s) {
+            try {
+                if (s && s.destroy) s.destroy();
+            } catch (e) { /* ignore */ }
+        });
+        aranhaSortInstances = [];
+    }
+
+    function syncAranha3ItemsFromDOM(item) {
+        var zones = ['left', 'top', 'right', 'bottom', 'auto'];
+        var oldItems = item.settings.items || [];
+        var newItems = [];
+
+        zones.forEach(function (zone) {
+            $('#vitrine-settings-panel .vitrine-aranha-items-list[data-aranha-zone="' + zone + '"]').each(function () {
+                $(this).children('.vitrine-aranha-item').each(function () {
+                    var idx = parseInt($(this).data('aranha-idx'), 10);
+                    if (isNaN(idx) || !oldItems[idx]) return;
+                    var it = $.extend(true, {}, oldItems[idx]);
+                    it.position = zone === 'auto' ? 'auto' : zone;
+                    newItems.push(it);
+                });
+            });
+        });
+
+        item.settings.items = newItems;
+    }
+
+    function handleAranhaSortEnd(evt, item) {
+        var fromKey = $(evt.from).data('aranha-key');
+        var toKey = $(evt.to).data('aranha-key');
+        var oldIndex = evt.oldIndex;
+        var newIndex = evt.newIndex;
+
+        if (item.type === 'aranha3') {
+            syncAranha3ItemsFromDOM(item);
+            renderSettings();
+            renderCanvas();
+            return;
+        }
+
+        if (!fromKey || !toKey) return;
+
+        if (item.type === 'aranha') {
+            if (!item.settings[fromKey]) item.settings[fromKey] = [];
+            if (!item.settings[toKey]) item.settings[toKey] = [];
+            var movedAranha = item.settings[fromKey].splice(oldIndex, 1)[0];
+            if (!movedAranha) return;
+            item.settings[toKey].splice(newIndex, 0, movedAranha);
+        } else if (item.type === 'aranha2') {
+            var arr = item.settings[fromKey];
+            if (!arr) return;
+            var movedA2 = arr.splice(oldIndex, 1)[0];
+            if (!movedA2) return;
+            arr.splice(newIndex, 0, movedA2);
+        }
+
+        renderSettings();
+        renderCanvas();
+    }
 
     function destroyAllMCE() {
+        destroyAranhaSort();
         _skipMCESync = true;
         $('.vitrine-aranha-mce, .vitrine-field-mce, .vitrine-toggle-mce').each(function () {
             var id = $(this).attr('id');
@@ -1658,52 +1316,83 @@
     }
 
     function initAranhaSort() {
-        $('.vitrine-aranha-items-list').each(function () {
-            var $list = $(this);
-            if ($list.data('sortable-init')) return; // evita dupla init
-            $list.data('sortable-init', true);
+        destroyAranhaSort();
+        if (!selectedId) return;
+        var item = findItemById(selectedId);
+        if (!item || item.type.indexOf('aranha') !== 0) return;
 
-            Sortable.create(this, {
+        var groupName = 'aranha-items-' + selectedId;
+
+        $('#vitrine-settings-panel .vitrine-aranha-items-list').each(function () {
+            var instance = Sortable.create(this, {
+                group: { name: groupName, pull: true, put: true },
                 handle: '.vitrine-aranha-drag',
                 draggable: '.vitrine-aranha-item',
                 animation: 150,
                 ghostClass: 'vitrine-aranha-ghost',
+                emptyInsertThreshold: 12,
                 onEnd: function (evt) {
-                    if (evt.oldIndex === evt.newIndex) return;
-                    if (!selectedId) return;
-                    var item = findItemById(selectedId);
-                    if (!item) return;
-
-                    var key = $list.data('aranha-key');
-                    if (!key || !item.settings[key]) return;
-
-                    // Lê a nova ordem pelos índices originais ainda no DOM
-                    var arr = item.settings[key];
-                    var newOrder = [];
-                    $list.children('.vitrine-aranha-item').each(function () {
-                        var idx = parseInt($(this).data('aranha-idx'), 10);
-                        if (!isNaN(idx) && arr[idx]) newOrder.push(arr[idx]);
-                    });
-                    item.settings[key] = newOrder;
-
-                    renderSettings();
-                    renderCanvas();
+                    if (evt.oldIndex === evt.newIndex && evt.from === evt.to) return;
+                    var current = findItemById(selectedId);
+                    if (!current) return;
+                    handleAranhaSortEnd(evt, current);
                 }
             });
+            aranhaSortInstances.push(instance);
+        });
+    }
+
+    function aranhaMceId(key, idx, prop) {
+        return 'vitrine-aranha-mce-' + String(key).replace(/_/g, '-') + '-' + idx + '-' + prop;
+    }
+
+    function stripHtmlPreview(html) {
+        var div = document.createElement('div');
+        div.innerHTML = html || '';
+        return (div.textContent || div.innerText || '').trim();
+    }
+
+    function defaultAranhaItem(type) {
+        if (type === 'aranha3') {
+            return { title: '', text: '', icon: '', link: '', position: 'auto' };
+        }
+        return { text: '', icon: '', link: '' };
+    }
+
+    function syncAllAranhaMCE() {
+        if (_skipMCESync) return;
+        $('.vitrine-aranha-mce').each(function () {
+            var id = $(this).attr('id');
+            if (id) {
+                syncAranhaMCE(id, true);
+            }
+        });
+    }
+
+    function syncAllFieldMCE() {
+        if (_skipMCESync) return;
+        $('.vitrine-field-mce').each(function () {
+            var id = $(this).attr('id');
+            if (id) {
+                syncFieldMCE(id);
+            }
         });
     }
 
     function initAranhaMCE() {
+        if (typeof wp === 'undefined' || !wp.editor) return;
         $('.vitrine-aranha-mce').each(function () {
             var id = $(this).attr('id');
             if (!id) return;
+            if (typeof tinymce !== 'undefined' && tinymce.get(id)) return;
+
             wp.editor.initialize(id, {
                 tinymce: {
-                    toolbar1: 'bold,italic,underline,link,bullist',
+                    toolbar1: 'bold,italic,underline,link,bullist,numlist,alignleft,aligncenter,alignright',
                     menubar: false,
                     branding: false,
-                    resize: false,
-                    height: 80,
+                    resize: true,
+                    height: 100,
                     setup: function (editor) {
                         editor.on('change keyup', function () {
                             editor.save();
@@ -1711,52 +1400,61 @@
                         });
                     }
                 },
-                quicktags: false,
+                quicktags: true,
                 mediaButtons: false
             });
         });
     }
 
-    function syncAranhaMCE(editorId) {
+    function syncAranhaMCE(editorId, silent) {
+        if (_skipMCESync) return;
         if (!selectedId) return;
         var item = findItemById(selectedId);
         if (!item) return;
 
         var $ta      = $('#' + editorId);
-        var $item    = $ta.closest('.vitrine-aranha-item');
+        if (!$ta.length) return;
+
+        var $itemEl  = $ta.closest('.vitrine-aranha-item');
         var $section = $ta.closest('.vitrine-aranha-section');
-        var key = $section.data('aranha-key');
-        var idx = $item.data('aranha-idx');
+        var key      = $section.data('aranha-key');
+        var idx      = $itemEl.data('aranha-idx');
+        var prop     = $ta.data('aranha-prop') || 'text';
+
+        if (key === undefined || idx === undefined) return;
 
         if (!item.settings[key]) item.settings[key] = [];
-        if (!item.settings[key][idx]) item.settings[key][idx] = { text: '', icon: '', link: '' };
+        if (!item.settings[key][idx]) {
+            item.settings[key][idx] = defaultAranhaItem(item.type);
+        }
 
-        var content = (typeof wp !== 'undefined' && wp.editor)
+        var content = (typeof wp !== 'undefined' && wp.editor && wp.editor.getContent)
             ? wp.editor.getContent(editorId)
             : $ta.val();
 
-        item.settings[key][idx].text = content;
+        item.settings[key][idx][prop] = content;
 
-        // Atualiza preview
-        var $block = $('[data-id="' + selectedId + '"]').first().find('> .vitrine-block-preview');
-        var elDef  = elements[item.type];
-        if ($block.length && elDef) {
-            var s = $.extend(true, {}, elDef.defaults, item.settings);
-            $block.html(buildPreview(item.type, s));
+        if (!silent && (prop === 'text' || prop === 'title')) {
+            var preview = stripHtmlPreview(content);
+            var fallback = prop === 'title' ? 'Card sem título' : 'Item sem rótulo';
+            $itemEl.find('.vitrine-a2-item-preview-text').text(preview || fallback);
         }
     }
 
     function initFieldMCE() {
+        if (typeof wp === 'undefined' || !wp.editor) return;
         $('.vitrine-field-mce').each(function () {
             var id = $(this).attr('id');
             if (!id) return;
+            if (typeof tinymce !== 'undefined' && tinymce.get(id)) return;
+
             wp.editor.initialize(id, {
                 tinymce: {
                     toolbar1: 'bold,italic,underline,link,bullist,numlist,alignleft,aligncenter,alignright',
                     menubar: false,
                     branding: false,
-                    resize: false,
-                    height: 120,
+                    resize: true,
+                    height: 160,
                     setup: function (editor) {
                         editor.on('change keyup', function () {
                             editor.save();
@@ -1764,7 +1462,7 @@
                         });
                     }
                 },
-                quicktags: false,
+                quicktags: true,
                 mediaButtons: false
             });
         });
@@ -1854,18 +1552,20 @@
         }
         var items = item.settings[key];
 
-        var html = '<div class="vitrine-aranha-section" data-aranha-key="' + key + '">';
+        var html = '<div class="vitrine-aranha-section vitrine-aranha-zone-section" data-aranha-key="' + key + '">';
         html += '<hr style="border:none;border-top:1px solid #dcdcde;margin:14px 0 10px;" />';
         html += '<h4 class="vitrine-aranha-section-title">' + escapeHtml(sectionLabel) + ' (' + items.length + ')</h4>';
+        html += '<div class="vitrine-aranha-items-list" data-aranha-key="' + key + '">';
 
         items.forEach(function (ai, idx) {
             html += '<div class="vitrine-aranha-item" data-aranha-idx="' + idx + '">';
             html += '<div class="vitrine-aranha-item-header">';
+            html += '<span class="vitrine-aranha-drag dashicons dashicons-move" title="Arrastar para mover ou reordenar"></span>';
             html += '<span class="vitrine-aranha-item-num">' + (idx + 1) + '</span>';
             html += '<button type="button" class="button button-small vitrine-aranha-remove-item" title="Remover">&times;</button>';
             html += '</div>';
-            html += '<div class="vitrine-field-group"><label>Texto</label>';
-            html += '<textarea id="vitrine-aranha-mce-' + key + '-' + idx + '" class="vitrine-aranha-mce" data-aranha-prop="text" rows="3">' + escapeHtml(ai.text || '') + '</textarea>';
+            html += '<div class="vitrine-field-group vitrine-field-group--full"><label>Texto</label>';
+            html += '<textarea id="' + aranhaMceId(key, idx, 'text') + '" class="vitrine-aranha-mce" data-aranha-prop="text" rows="4">' + (ai.text || '') + '</textarea>';
             html += '</div>';
             html += '<div class="vitrine-field-group"><label>Link</label>';
             html += '<input type="text" class="vitrine-aranha-field" data-aranha-prop="link" value="' + escapeAttr(ai.link || '') + '" placeholder="https://" /></div>';
@@ -1880,38 +1580,12 @@
                 html += ' <button type="button" class="button vitrine-aranha-remove-icon">Remover</button>';
             }
             html += '</div>';
-            // Painel picker (fechado por padrão)
-            html += '<div class="vitrine-icon-picker" style="display:none;">';
-            html += '<div class="vitrine-icon-picker-tabs">';
-            html += '<button type="button" class="vitrine-icon-tab is-active" data-tab="upload">Imagem</button>';
-            html += '<button type="button" class="vitrine-icon-tab" data-tab="dashicons">Dashicons</button>';
-            html += '<button type="button" class="vitrine-icon-tab" data-tab="fa">Font Awesome</button>';
-            html += '</div>';
-            // Aba: Imagem
-            html += '<div class="vitrine-icon-tab-panel" data-panel="upload">';
-            html += '<button type="button" class="button vitrine-aranha-select-icon">Selecionar da Biblioteca</button>';
-            html += '</div>';
-            // Aba: Dashicons
-            html += '<div class="vitrine-icon-tab-panel" data-panel="dashicons" style="display:none;">';
-            html += '<input type="text" class="vitrine-icon-search" placeholder="Filtrar dashicons..." />';
-            html += '<div class="vitrine-icons-grid">';
-            DASHICONS_LIST.forEach(function (d) {
-                html += '<button type="button" class="vitrine-icon-pick" data-icon="' + escapeAttr(d) + '" title="' + escapeAttr(d) + '"><span class="dashicons ' + escapeAttr(d) + '"></span></button>';
-            });
-            html += '</div></div>';
-            // Aba: Font Awesome
-            html += '<div class="vitrine-icon-tab-panel" data-panel="fa" style="display:none;">';
-            html += '<input type="text" class="vitrine-icon-search" placeholder="Filtrar ícones FA..." />';
-            html += '<div class="vitrine-icons-grid">';
-            FA_ICONS_LIST.forEach(function (f) {
-                html += '<button type="button" class="vitrine-icon-pick" data-icon="' + escapeAttr(f) + '" title="' + escapeAttr(f) + '"><i class="' + escapeAttr(f) + '"></i></button>';
-            });
-            html += '</div></div>';
-            html += '</div>'; // picker
+            html += buildIconPickerHtml();
             html += '</div></div>'; // icon-field + field-group
             html += '</div>';
         });
 
+        html += '</div>';
         html += '<button type="button" class="button vitrine-aranha-add-item">+ Adicionar Item</button>';
         html += '</div>';
 
@@ -1924,28 +1598,23 @@
     function buildIconPickerHtml() {
         var h = '<div class="vitrine-icon-picker" style="display:none;">';
         h += '<div class="vitrine-icon-picker-tabs">';
-        h += '<button type="button" class="vitrine-icon-tab is-active" data-tab="upload">Imagem</button>';
-        h += '<button type="button" class="vitrine-icon-tab" data-tab="dashicons">Dashicons</button>';
+        h += '<button type="button" class="vitrine-icon-tab is-active" data-tab="dashicons">Dashicons</button>';
         h += '<button type="button" class="vitrine-icon-tab" data-tab="fa">Font Awesome</button>';
+        h += '<button type="button" class="vitrine-icon-tab" data-tab="upload">Imagem</button>';
         h += '</div>';
-        h += '<div class="vitrine-icon-tab-panel" data-panel="upload">';
-        h += '<button type="button" class="button vitrine-aranha-select-icon">Selecionar da Biblioteca</button>';
-        h += '</div>';
-        h += '<div class="vitrine-icon-tab-panel" data-panel="dashicons" style="display:none;">';
+        h += '<div class="vitrine-icon-tab-panel" data-panel="dashicons">';
         h += '<input type="text" class="vitrine-icon-search" placeholder="Filtrar dashicons..." />';
-        h += '<div class="vitrine-icons-grid">';
-        DASHICONS_LIST.forEach(function (d) {
-            h += '<button type="button" class="vitrine-icon-pick" data-icon="' + escapeAttr(d) + '" title="' + escapeAttr(d) + '"><span class="dashicons ' + escapeAttr(d) + '"></span></button>';
-        });
-        h += '</div></div>';
+        h += '<div class="vitrine-icons-grid"></div>';
+        h += '</div>';
         h += '<div class="vitrine-icon-tab-panel" data-panel="fa" style="display:none;">';
         h += '<input type="text" class="vitrine-icon-search" placeholder="Filtrar ícones FA..." />';
-        h += '<div class="vitrine-icons-grid">';
-        FA_ICONS_LIST.forEach(function (f) {
-            h += '<button type="button" class="vitrine-icon-pick" data-icon="' + escapeAttr(f) + '" title="' + escapeAttr(f) + '"><i class="' + escapeAttr(f) + '"></i></button>';
-        });
-        h += '</div></div>';
-        h += '</div>'; // picker
+        h += '<div class="vitrine-icons-grid"></div>';
+        h += '</div>';
+        h += '<div class="vitrine-icon-tab-panel" data-panel="upload" style="display:none;">';
+        h += '<p class="vitrine-field-hint" style="margin:0 0 8px;">Use imagem apenas se não houver ícone adequado.</p>';
+        h += '<button type="button" class="button vitrine-aranha-select-icon">Selecionar da Biblioteca</button>';
+        h += '</div>';
+        h += '</div>';
         return h;
     }
 
@@ -1965,7 +1634,7 @@
         html += '<div class="vitrine-a2-section-head">';
         html += '<div>';
         html += '<h4 class="vitrine-aranha-section-title">Itens Orbitais</h4>';
-        html += '<p class="vitrine-a2-section-hint">Distribuídos automaticamente ao redor da imagem central. Arraste para reordenar.</p>';
+        html += '<p class="vitrine-a2-section-hint">Arraste para reordenar a posição de cada card no círculo.</p>';
         html += '</div>';
         html += '<span class="vitrine-a2-count-badge">' + items.length + '</span>';
         html += '</div>';
@@ -1983,7 +1652,7 @@
             html += '<div class="vitrine-a2-item-header">';
             html += '<span class="vitrine-aranha-drag dashicons dashicons-move" title="Arrastar para reordenar"></span>';
             html += '<span class="vitrine-aranha-item-num">' + (idx + 1) + '</span>';
-            html += '<span class="vitrine-a2-item-preview-text">' + escapeHtml(ai.text || 'Item ' + (idx + 1)) + '</span>';
+            html += '<span class="vitrine-a2-item-preview-text">' + escapeHtml(stripHtmlPreview(ai.text) || ('Item ' + (idx + 1))) + '</span>';
             if (hasIcon) { html += '<span class="vitrine-a2-badge vitrine-a2-badge--icon" title="Tem ícone"><span class="dashicons dashicons-format-image"></span></span>'; }
             if (hasLink) { html += '<span class="vitrine-a2-badge vitrine-a2-badge--link" title="Tem link"><span class="dashicons dashicons-admin-links"></span></span>'; }
             html += '<button type="button" class="button button-small vitrine-aranha-remove-item" title="Remover item">&times;</button>';
@@ -2022,11 +1691,9 @@
             html += '<div class="vitrine-a2-fields-col">';
 
             // Campo: rótulo/texto
-            html += '<div class="vitrine-field-group">';
+            html += '<div class="vitrine-field-group vitrine-field-group--full">';
             html += '<label>Rótulo</label>';
-            html += '<input type="text" class="vitrine-aranha-field vitrine-a2-text-input" data-aranha-prop="text"'
-                + ' value="' + escapeAttr(ai.text || '') + '"'
-                + ' placeholder="Nome ou texto exibido..." />';
+            html += '<textarea id="' + aranhaMceId('items', idx, 'text') + '" class="vitrine-aranha-mce" data-aranha-prop="text" rows="4">' + (ai.text || '') + '</textarea>';
             html += '</div>';
 
             // Campo: link
@@ -2055,110 +1722,127 @@
         $panel.append(html);
     }
 
+    function buildAranha3ItemHtml(ai, idx) {
+        var hasIcon = !!ai.icon;
+        var hasLink = !!ai.link;
+        var html = '<div class="vitrine-aranha-item vitrine-a3-item" data-aranha-idx="' + idx + '">';
+
+        html += '<div class="vitrine-a2-item-header">';
+        html += '<span class="vitrine-aranha-drag dashicons dashicons-move" title="Arrastar para mover entre posições"></span>';
+        html += '<span class="vitrine-aranha-item-num">' + (idx + 1) + '</span>';
+        html += '<span class="vitrine-a2-item-preview-text">' + escapeHtml(stripHtmlPreview(ai.title) || ('Card ' + (idx + 1))) + '</span>';
+        if (hasIcon) { html += '<span class="vitrine-a2-badge vitrine-a2-badge--icon" title="Tem ícone"><span class="dashicons dashicons-format-image"></span></span>'; }
+        if (hasLink) { html += '<span class="vitrine-a2-badge vitrine-a2-badge--link" title="Tem link"><span class="dashicons dashicons-admin-links"></span></span>'; }
+        html += '<button type="button" class="button button-small vitrine-aranha-remove-item" title="Remover">&times;</button>';
+        html += '</div>';
+
+        html += '<div class="vitrine-a2-item-body vitrine-a3-item-body">';
+
+        html += '<div class="vitrine-aranha-icon-field vitrine-a2-icon-col vitrine-a3-icon-col">';
+        var iconPreview = hasIcon
+            ? renderIconPreviewHtml(ai.icon)
+            : '<span class="dashicons dashicons-format-image" style="font-size:28px;width:28px;height:28px;color:#c3c4c7;"></span>';
+
+        html += '<div class="vitrine-a2-icon-display vitrine-aranha-open-picker" title="Clique para escolher ícone ou imagem">';
+        html += '<div class="vitrine-icon-current">' + iconPreview + '</div>';
+        html += '<span class="vitrine-a2-icon-hint">' + (hasIcon ? 'Trocar' : 'Adicionar') + '</span>';
+        html += '</div>';
+
+        html += '<input type="hidden" class="vitrine-aranha-field" data-aranha-prop="icon" value="' + escapeAttr(ai.icon || '') + '" />';
+
+        html += '<div class="vitrine-icon-actions vitrine-a2-icon-actions">';
+        if (hasIcon) {
+            html += '<button type="button" class="button vitrine-aranha-remove-icon">Remover</button>';
+        }
+        html += '</div>';
+
+        html += buildIconPickerHtml();
+        html += '</div>';
+
+        html += '<div class="vitrine-a2-fields-col vitrine-a3-fields-col">';
+
+        html += '<div class="vitrine-field-group">';
+        html += '<label>Posição no grid</label>';
+        html += '<select class="vitrine-aranha-field" data-aranha-prop="position">';
+        var posVal = ai.position || 'auto';
+        html += '<option value="auto"' + (posVal === 'auto' ? ' selected' : '') + '>Automático</option>';
+        html += '<option value="top"' + (posVal === 'top' ? ' selected' : '') + '>Topo</option>';
+        html += '<option value="bottom"' + (posVal === 'bottom' ? ' selected' : '') + '>Base</option>';
+        html += '<option value="left"' + (posVal === 'left' ? ' selected' : '') + '>Esquerda</option>';
+        html += '<option value="right"' + (posVal === 'right' ? ' selected' : '') + '>Direita</option>';
+        html += '</select>';
+        html += '<p class="vitrine-field-hint">Ou arraste o card para outra zona abaixo.</p>';
+        html += '</div>';
+
+        html += '<div class="vitrine-field-group vitrine-field-group--full">';
+        html += '<label>Título</label>';
+        html += '<textarea id="' + aranhaMceId('items', idx, 'title') + '" class="vitrine-aranha-mce" data-aranha-prop="title" rows="3">' + (ai.title || '') + '</textarea>';
+        html += '</div>';
+
+        html += '<div class="vitrine-field-group vitrine-field-group--full">';
+        html += '<label>Descrição</label>';
+        html += '<textarea id="' + aranhaMceId('items', idx, 'text') + '" class="vitrine-aranha-mce" data-aranha-prop="text" rows="5">' + (ai.text || '') + '</textarea>';
+        html += '</div>';
+
+        html += '<div class="vitrine-field-group">';
+        html += '<label><span class="dashicons dashicons-admin-links" style="font-size:13px;vertical-align:middle;margin-right:3px;color:#0073aa;"></span>Link <span style="font-weight:400;color:#8c8f94;">(opcional)</span></label>';
+        html += '<input type="text" class="vitrine-aranha-field" data-aranha-prop="link"'
+            + ' value="' + escapeAttr(ai.link || '') + '"'
+            + ' placeholder="https://..." />';
+        html += '<p class="vitrine-field-hint">Torna o card clicável.</p>';
+        html += '</div>';
+
+        html += '</div>';
+        html += '</div>';
+        html += '</div>';
+
+        return html;
+    }
+
     /* ──────────────────────────────────────────────────────
-       Aranha Grade (aranha3) — repeater de cards
+       Aranha Grade (aranha3) — repeater por zona do grid
     ────────────────────────────────────────────────────── */
     function renderAranha3Repeater($panel, item) {
         if (!item.settings.items || !Array.isArray(item.settings.items)) {
             item.settings.items = [];
         }
         var items = item.settings.items;
+        var zones = [
+            { id: 'left',   label: 'Esquerda' },
+            { id: 'top',    label: 'Topo' },
+            { id: 'right',  label: 'Direita' },
+            { id: 'bottom', label: 'Base' },
+            { id: 'auto',   label: 'Automático' }
+        ];
 
         var html = '<div class="vitrine-aranha-section vitrine-a3-section" data-aranha-key="items">';
+        html += '<hr style="border:none;border-top:1px solid #dcdcde;margin:14px 0 10px;" />';
         html += '<h4 class="vitrine-aranha-section-title" style="margin:0 0 4px;">Cards do Grid</h4>';
-        html += '<p style="margin:0 0 10px;font-size:11px;color:#8c8f94;line-height:1.5;">Ordem recomendada: esquerda → topo (3) → direita → base (3). Use <strong>Posição</strong> para fixar cada card.</p>';
-        html += '<div class="vitrine-a3-items-header" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">';
-        html += '<span style="font-size:11px;color:#8c8f94;">' + items.length + ' card' + (items.length !== 1 ? 's' : '') + '</span>';
-        html += '</div>';
+        html += '<p class="vitrine-field-hint" style="margin:0 0 12px;">Arraste os cards entre as zonas para definir onde aparecem no layout. Total: ' + items.length + '.</p>';
 
-        html += '<div class="vitrine-aranha-items-list vitrine-a3-items-list" data-aranha-key="items">';
+        zones.forEach(function (zone) {
+            var zoneItems = [];
+            items.forEach(function (ai, idx) {
+                var pos = ai.position || 'auto';
+                if (pos === zone.id) {
+                    zoneItems.push({ ai: ai, idx: idx });
+                }
+            });
 
-        items.forEach(function (ai, idx) {
-            var hasIcon = !!ai.icon;
-            var hasLink = !!ai.link;
+            html += '<div class="vitrine-aranha-zone-section vitrine-a3-zone" data-aranha-key="items" data-aranha-zone="' + zone.id + '">';
+            html += '<h5 class="vitrine-aranha-zone-title">' + escapeHtml(zone.label) + ' <span class="vitrine-aranha-zone-count">(' + zoneItems.length + ')</span></h5>';
+            html += '<div class="vitrine-aranha-items-list vitrine-a3-items-list" data-aranha-key="items" data-aranha-zone="' + zone.id + '">';
 
-            html += '<div class="vitrine-aranha-item vitrine-a3-item" data-aranha-idx="' + idx + '">';
-
-            html += '<div class="vitrine-a2-item-header">';
-            html += '<span class="vitrine-aranha-drag dashicons dashicons-move" title="Arrastar para reordenar"></span>';
-            html += '<span class="vitrine-aranha-item-num">' + (idx + 1) + '</span>';
-            html += '<span class="vitrine-a2-item-preview-text">' + escapeHtml(ai.title || 'Card ' + (idx + 1)) + '</span>';
-            if (hasIcon) { html += '<span class="vitrine-a2-badge vitrine-a2-badge--icon" title="Tem ícone"><span class="dashicons dashicons-format-image"></span></span>'; }
-            if (hasLink) { html += '<span class="vitrine-a2-badge vitrine-a2-badge--link" title="Tem link"><span class="dashicons dashicons-admin-links"></span></span>'; }
-            html += '<button type="button" class="button button-small vitrine-aranha-remove-item" title="Remover">&times;</button>';
-            html += '</div>';
-
-            html += '<div class="vitrine-a2-item-body vitrine-a3-item-body">';
-
-            html += '<div class="vitrine-aranha-icon-field vitrine-a2-icon-col vitrine-a3-icon-col">';
-            var iconPreview = hasIcon
-                ? renderIconPreviewHtml(ai.icon)
-                : '<span class="dashicons dashicons-format-image" style="font-size:28px;width:28px;height:28px;color:#c3c4c7;"></span>';
-
-            html += '<div class="vitrine-a2-icon-display vitrine-aranha-open-picker" title="Clique para escolher ícone ou imagem">';
-            html += '<div class="vitrine-icon-current">' + iconPreview + '</div>';
-            html += '<span class="vitrine-a2-icon-hint">' + (hasIcon ? 'Trocar' : 'Adicionar') + '</span>';
-            html += '</div>';
-
-            html += '<input type="hidden" class="vitrine-aranha-field" data-aranha-prop="icon" value="' + escapeAttr(ai.icon || '') + '" />';
-
-            html += '<div class="vitrine-icon-actions vitrine-a2-icon-actions">';
-            if (hasIcon) {
-                html += '<button type="button" class="button vitrine-aranha-remove-icon">Remover</button>';
-            }
-            html += '</div>';
-
-            html += buildIconPickerHtml();
-            html += '</div>';
-
-            html += '<div class="vitrine-a2-fields-col vitrine-a3-fields-col">';
-
-            html += '<div class="vitrine-field-group">';
-            html += '<label>Posição no grid</label>';
-            html += '<select class="vitrine-aranha-field" data-aranha-prop="position">';
-            var posVal = ai.position || 'auto';
-            html += '<option value="auto"' + (posVal === 'auto' ? ' selected' : '') + '>Automático</option>';
-            html += '<option value="top"' + (posVal === 'top' ? ' selected' : '') + '>Topo</option>';
-            html += '<option value="bottom"' + (posVal === 'bottom' ? ' selected' : '') + '>Base</option>';
-            html += '<option value="left"' + (posVal === 'left' ? ' selected' : '') + '>Esquerda</option>';
-            html += '<option value="right"' + (posVal === 'right' ? ' selected' : '') + '>Direita</option>';
-            html += '</select>';
-            html += '<p class="vitrine-field-hint">Fixa o card na lateral ou faixa desejada.</p>';
-            html += '</div>';
-
-            html += '<div class="vitrine-field-group">';
-            html += '<label>Título</label>';
-            html += '<input type="text" class="vitrine-aranha-field vitrine-a3-title-input" data-aranha-prop="title"'
-                + ' value="' + escapeAttr(ai.title || '') + '"'
-                + ' placeholder="Título do card..." />';
-            html += '</div>';
-
-            html += '<div class="vitrine-field-group">';
-            html += '<label>Descrição</label>';
-            html += '<textarea class="vitrine-aranha-field" data-aranha-prop="text"'
-                + ' rows="3" placeholder="Texto do card...">' + escapeHtml(ai.text || '') + '</textarea>';
-            html += '</div>';
-
-            html += '<div class="vitrine-field-group">';
-            html += '<label><span class="dashicons dashicons-admin-links" style="font-size:13px;vertical-align:middle;margin-right:3px;color:#0073aa;"></span>Link <span style="font-weight:400;color:#8c8f94;">(opcional)</span></label>';
-            html += '<input type="text" class="vitrine-aranha-field" data-aranha-prop="link"'
-                + ' value="' + escapeAttr(ai.link || '') + '"'
-                + ' placeholder="https://..." />';
-            html += '<p class="vitrine-field-hint">Torna o card clicável.</p>';
-            html += '</div>';
+            zoneItems.forEach(function (entry) {
+                html += buildAranha3ItemHtml(entry.ai, entry.idx);
+            });
 
             html += '</div>';
-            html += '</div>';
+            html += '<button type="button" class="button button-small vitrine-aranha-add-item vitrine-a3-add-btn">+ Adicionar em ' + escapeHtml(zone.label) + '</button>';
             html += '</div>';
         });
 
-        html += '</div>'; // items-list
-
-        html += '<button type="button" class="button vitrine-aranha-add-item vitrine-a3-add-btn" style="width:100%;margin-top:8px;justify-content:center;">'
-            + '<span class="dashicons dashicons-plus-alt2" style="margin-top:3px;"></span> Adicionar Card'
-            + '</button>';
-
-        html += '</div>'; // section
+        html += '</div>';
 
         $panel.append(html);
     }
@@ -2173,6 +1857,7 @@
 
         var field = $(this).data('field');
         var val   = $(this).val();
+        var elDef = elements[item.type];
         item.settings[field] = val;
 
         if ($(this).hasClass('vitrine-field-range')) {
@@ -2191,9 +1876,16 @@
             return;
         }
 
+        if (item.type === 'container' && field === 'name') {
+            var mergedSettings = $.extend({}, elDef.defaults, item.settings);
+            var displayName = getContainerDisplayName(mergedSettings);
+            var $rootBlock = $('[data-id="' + selectedId + '"]').first();
+            $rootBlock.find('> .vitrine-block-toolbar .vitrine-block-label').text(displayName);
+            $('#vitrine-settings-el-label').text(displayName);
+        }
+
         // Re-renderiza preview do bloco selecionado
         var $block = $('[data-id="' + selectedId + '"]').first().find('> .vitrine-block-preview');
-        var elDef  = elements[item.type];
         if ($block.length && elDef) {
             var settings = $.extend({}, elDef.defaults, item.settings);
             $block.html(buildPreview(item.type, settings));
@@ -2308,6 +2000,12 @@
         }
         item.settings[key][idx][prop] = $(this).val();
 
+        if (item.type === 'aranha3' && prop === 'position') {
+            renderSettings();
+            renderCanvas();
+            return;
+        }
+
         // Atualiza preview
         var $block = $('[data-id="' + selectedId + '"]').first().find('> .vitrine-block-preview');
         var elDef  = elements[item.type];
@@ -2325,9 +2023,16 @@
         if (!item) return;
 
         var key = $(this).closest('.vitrine-aranha-section').data('aranha-key');
+        var zone = $(this).closest('.vitrine-aranha-section').data('aranha-zone');
         if (!item.settings[key]) item.settings[key] = [];
         if (item.type === 'aranha3') {
-            item.settings[key].push({ title: '', text: '', icon: '', link: '', position: 'auto' });
+            item.settings[key].push({
+                title: '',
+                text: '',
+                icon: '',
+                link: '',
+                position: zone && zone !== 'auto' ? zone : 'auto'
+            });
         } else {
             item.settings[key].push({ text: '', icon: '', link: '' });
         }
@@ -2360,8 +2065,12 @@
     $(document).on('click', '.vitrine-aranha-open-picker', function (e) {
         e.stopPropagation();
         var $picker = $(this).closest('.vitrine-aranha-icon-field').find('.vitrine-icon-picker');
-        $('.vitrine-icon-picker').not($picker).hide(); // fecha outros
+        $('.vitrine-icon-picker').not($picker).hide();
+        var willShow = !$picker.is(':visible');
         $picker.toggle();
+        if (willShow) {
+            ensureIconGrid($picker, 'dashicons');
+        }
     });
 
     // Trocar aba do picker
@@ -2372,6 +2081,7 @@
         $(this).addClass('is-active');
         $picker.find('.vitrine-icon-tab-panel').hide();
         $picker.find('[data-panel="' + tab + '"]').show();
+        ensureIconGrid($picker, tab);
     });
 
     // Filtrar ícones no grid
@@ -2435,19 +2145,6 @@
         if (!$(e.target).closest('.vitrine-aranha-icon-field').length) {
             $('.vitrine-icon-picker').hide();
         }
-    });
-
-    // Aranha2: atualizar preview do header ao digitar o rótulo
-    $(document).on('input', '.vitrine-a2-text-input', function () {
-        var val = $(this).val();
-        var $item = $(this).closest('.vitrine-a2-item');
-        $item.find('.vitrine-a2-item-preview-text').text(val || 'Item sem rótulo');
-    });
-
-    // Aranha3: atualizar preview do título no header do card
-    $(document).on('input', '.vitrine-a3-title-input', function () {
-        var val = $(this).val();
-        $(this).closest('.vitrine-a3-item').find('.vitrine-a2-item-preview-text').text(val || 'Card sem título');
     });
 
     // Aranha2/3: atualizar badge de link ao alterar campo link
@@ -2536,68 +2233,20 @@
         renderCanvas();
     });
 
-    /* ──────────────────── Imagem + Links: Eventos dos itens dinâmicos ──────────────────── */
-
-    function refreshImagelinksPreview() {
-        if (!selectedId) return;
-        var item = findItemById(selectedId);
-        if (!item || item.type !== 'imagelinks') return;
-        var $block = $('[data-id="' + selectedId + '"]').first().find('> .vitrine-block-preview');
-        var elDef  = elements[item.type];
-        if ($block.length && elDef) {
-            var s = $.extend(true, {}, elDef.defaults, item.settings);
-            $block.html(buildPreview(item.type, s));
-        }
-    }
-
-    $(document).on('input change', '.vitrine-imagelinks-field', function () {
-        if (!selectedId) return;
-        var item = findItemById(selectedId);
-        if (!item) return;
-
-        var $iItem = $(this).closest('.vitrine-imagelinks-editor-item');
-        var idx    = $iItem.data('imagelinks-idx');
-        var prop   = $(this).data('imagelinks-prop');
-
-        if (!item.settings.items) item.settings.items = [];
-        if (!item.settings.items[idx]) item.settings.items[idx] = { label: '', url: '' };
-        item.settings.items[idx][prop] = $(this).val();
-
-        refreshImagelinksPreview();
-    });
-
-    $(document).on('click', '.vitrine-imagelinks-add-item', function (e) {
-        e.preventDefault();
-        if (!selectedId) return;
-        var item = findItemById(selectedId);
-        if (!item) return;
-
-        if (!item.settings.items) item.settings.items = [];
-        item.settings.items.push({ label: '', url: '' });
-
-        renderSettings();
-        renderCanvas();
-    });
-
-    $(document).on('click', '.vitrine-imagelinks-remove-item', function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!selectedId) return;
-        var item = findItemById(selectedId);
-        if (!item) return;
-
-        var idx = $(this).closest('.vitrine-imagelinks-editor-item').data('imagelinks-idx');
-        if (item.settings.items) {
-            item.settings.items.splice(idx, 1);
-        }
-
-        renderSettings();
-        renderCanvas();
-    });
-
     /* ──────────────────── Salvar Layout ──────────────────── */
 
+    function getBuilderPageSettings() {
+        return {
+            show_header:   pageSettings.show_header,
+            show_footer:   pageSettings.show_footer,
+            page_bg_color: pageSettings.page_bg_color,
+            custom_css:    pageSettings.custom_css || ''
+        };
+    }
+
     function saveLayout() {
+        syncAllAranhaMCE();
+        syncAllFieldMCE();
         var $btn = $('#vitrine-save-btn');
         $btn.prop('disabled', true).text('Salvando…');
 
@@ -2609,7 +2258,7 @@
                 nonce:         vitrineData.nonce,
                 post_id:       vitrineData.postId,
                 layout:        JSON.stringify(layout),
-                page_settings: JSON.stringify(pageSettings)
+                page_settings: JSON.stringify(getBuilderPageSettings())
             },
             success: function (res) {
                 if (res.success) {
@@ -2646,98 +2295,15 @@
             '</div>'
         );
 
-        // ── Hero Section UI ──
-        var heroImg       = pageSettings.hero_image || '';
-        var heroText      = pageSettings.hero_text || '';
-        var heroTxtColor  = pageSettings.hero_text_color || '#ffffff';
-        var heroOpacity   = pageSettings.hero_overlay_opacity || '50';
-        var heroHeight    = pageSettings.hero_height || '400';
-        var heroFontSize  = pageSettings.hero_font_size || '36';
-        var heroTextAlign = pageSettings.hero_text_align || 'center';
-        var heroDesc      = pageSettings.hero_description || '';
-        var heroDescSize  = pageSettings.hero_desc_size || '18';
-        var heroTextBold  = pageSettings.hero_text_bold !== '0';
-        var heroTextItal  = pageSettings.hero_text_italic === '1';
-        var heroDescBold  = false; // formatação agora é inline no HTML
-        var heroDescItal  = false;
-
-        $('#vitrine-editor-top').before(
-            '<div id="vitrine-hero-settings">' +
-                '<h4>Hero da Página</h4>' +
-                '<div class="vitrine-hero-fields">' +
-                    '<div class="vitrine-hero-field">' +
-                        '<label>Imagem de fundo</label>' +
-                        '<div class="vitrine-image-field vitrine-hero-image-field">' +
-                            (heroImg ? '<img src="' + escapeAttr(heroImg) + '" class="vitrine-image-preview" />' : '') +
-                            '<input type="hidden" id="vitrine-hero-image" value="' + escapeAttr(heroImg) + '" />' +
-                            '<button type="button" class="button" id="vitrine-hero-select-image">Selecionar</button>' +
-                            (heroImg ? ' <button type="button" class="button" id="vitrine-hero-remove-image">Remover</button>' : '') +
-                        '</div>' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field">' +
-                        '<label>Frase de destaque</label>' +
-                        '<input type="text" id="vitrine-hero-text" value="' + escapeAttr(heroText) + '" placeholder="Título do hero" />' +
-                        '<div class="vitrine-hero-format">' +
-                            '<button type="button" class="vitrine-format-btn' + (heroTextBold ? ' is-active' : '') + '" data-target="text" data-prop="bold" title="Negrito"><b>B</b></button>' +
-                            '<button type="button" class="vitrine-format-btn' + (heroTextItal ? ' is-active' : '') + '" data-target="text" data-prop="italic" title="Itálico"><i>I</i></button>' +
-                        '</div>' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field vitrine-hero-field--row">' +
-                        '<div>' +
-                            '<label>Tamanho do texto (px)</label>' +
-                            '<input type="number" id="vitrine-hero-font-size" value="' + escapeAttr(heroFontSize) + '" min="12" max="120" step="2" />' +
-                        '</div>' +
-                        '<div>' +
-                            '<label>Alinhamento</label>' +
-                            '<select id="vitrine-hero-text-align">' +
-                                '<option value="left"' + (heroTextAlign === 'left' ? ' selected' : '') + '>Esquerda</option>' +
-                                '<option value="center"' + (heroTextAlign === 'center' ? ' selected' : '') + '>Centro</option>' +
-                                '<option value="right"' + (heroTextAlign === 'right' ? ' selected' : '') + '>Direita</option>' +
-                            '</select>' +
-                        '</div>' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field vitrine-hero-field--wide">' +
-                        '<label>Descrição</label>' +
-                        '<div class="vitrine-wysiwyg-toolbar" id="vitrine-hero-desc-toolbar">' +
-                            '<button type="button" class="vitrine-wysiwyg-btn" data-cmd="bold" title="Negrito"><b>B</b></button>' +
-                            '<button type="button" class="vitrine-wysiwyg-btn" data-cmd="italic" title="Itálico"><i>I</i></button>' +
-                            '<button type="button" class="vitrine-wysiwyg-btn" data-cmd="underline" title="Sublinhado"><u>U</u></button>' +
-                            '<button type="button" class="vitrine-wysiwyg-btn" data-cmd="removeFormat" title="Limpar formatação">✕</button>' +
-                        '</div>' +
-                        '<div id="vitrine-hero-description" class="vitrine-aranha-wysiwyg" contenteditable="true">' + heroDesc + '</div>' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field">' +
-                        '<label>Tamanho da descrição (px)</label>' +
-                        '<input type="number" id="vitrine-hero-desc-size" value="' + escapeAttr(heroDescSize) + '" min="10" max="60" step="1" />' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field">' +
-                        '<label>Cor do texto</label>' +
-                        '<input type="color" id="vitrine-hero-text-color" value="' + escapeAttr(heroTxtColor) + '" />' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field">' +
-                        '<label>Opacidade do fade <span id="vitrine-hero-opacity-val">' + escapeHtml(heroOpacity) + '%</span></label>' +
-                        '<input type="range" id="vitrine-hero-opacity" min="0" max="100" value="' + escapeAttr(heroOpacity) + '" />' +
-                    '</div>' +
-                    '<div class="vitrine-hero-field">' +
-                        '<label>Altura (px)</label>' +
-                        '<input type="number" id="vitrine-hero-height" value="' + escapeAttr(heroHeight) + '" min="100" max="1000" step="10" />' +
-                    '</div>' +
-                '</div>' +
-                '<div id="vitrine-hero-preview"></div>' +
-            '</div>'
-        );
-
         var pageCustomCss = pageSettings.custom_css || '';
 
-        $('#vitrine-hero-settings').after(
+        $('#vitrine-editor').before(
             '<div id="vitrine-page-css-settings">' +
                 '<h4>CSS Personalizado da Vitrine</h4>' +
                 '<p class="vitrine-page-css-hint">Aplicado a <strong>toda esta vitrine</strong> no frontend. Use seletores como <code>#vitrine-single</code>, <code>.vitrine-front</code> ou <code>.vitrine-block</code>.</p>' +
                 '<textarea id="vitrine-page-custom-css" class="vitrine-page-css-textarea" rows="8" spellcheck="false" placeholder="#vitrine-single .vitrine-front {&#10;  max-width: 1400px;&#10;}">' + escapeHtml(pageCustomCss) + '</textarea>' +
             '</div>'
         );
-
-        renderHeroPreview();
 
         $(document).on('input change', '#vitrine-page-custom-css', function () {
             pageSettings.custom_css = $(this).val();
@@ -2759,91 +2325,6 @@
             pageSettings.page_bg_color = '';
             $('#vitrine-opt-bg').val('#ffffff');
             $(this).remove();
-        });
-
-        // ── Hero event handlers ──
-        $(document).on('click', '#vitrine-hero-select-image', function (e) {
-            e.preventDefault();
-            var frame = wp.media({ title: 'Imagem do Hero', multiple: false, library: { type: 'image' } });
-            frame.on('select', function () {
-                var url = frame.state().get('selection').first().toJSON().url;
-                pageSettings.hero_image = url;
-                $('#vitrine-hero-image').val(url);
-                var $wrap = $('.vitrine-hero-image-field');
-                $wrap.find('.vitrine-image-preview').remove();
-                $wrap.prepend('<img src="' + escapeAttr(url) + '" class="vitrine-image-preview" />');
-                if (!$('#vitrine-hero-remove-image').length) {
-                    $('#vitrine-hero-select-image').after(' <button type="button" class="button" id="vitrine-hero-remove-image">Remover</button>');
-                }
-                renderHeroPreview();
-            });
-            frame.open();
-        });
-
-        $(document).on('click', '#vitrine-hero-remove-image', function () {
-            pageSettings.hero_image = '';
-            $('#vitrine-hero-image').val('');
-            $('.vitrine-hero-image-field .vitrine-image-preview').remove();
-            $(this).remove();
-            renderHeroPreview();
-        });
-
-        $(document).on('input', '#vitrine-hero-text', function () {
-            pageSettings.hero_text = $(this).val();
-            renderHeroPreview();
-        });
-
-        $(document).on('input change', '#vitrine-hero-text-color', function () {
-            pageSettings.hero_text_color = $(this).val();
-            renderHeroPreview();
-        });
-
-        $(document).on('input', '#vitrine-hero-opacity', function () {
-            pageSettings.hero_overlay_opacity = $(this).val();
-            $('#vitrine-hero-opacity-val').text($(this).val() + '%');
-            renderHeroPreview();
-        });
-
-        $(document).on('input change', '#vitrine-hero-height', function () {
-            pageSettings.hero_height = $(this).val();
-            renderHeroPreview();
-        });
-
-        $(document).on('input change', '#vitrine-hero-font-size', function () {
-            pageSettings.hero_font_size = $(this).val();
-            renderHeroPreview();
-        });
-
-        $(document).on('change', '#vitrine-hero-text-align', function () {
-            pageSettings.hero_text_align = $(this).val();
-            renderHeroPreview();
-        });
-
-        $(document).on('input', '#vitrine-hero-description[contenteditable]', function () {
-            pageSettings.hero_description = $(this).html();
-            renderHeroPreview();
-        });
-
-        $(document).on('mousedown', '#vitrine-hero-desc-toolbar .vitrine-wysiwyg-btn', function (e) {
-            e.preventDefault();
-            var cmd = $(this).data('cmd');
-            document.execCommand(cmd, false, null);
-            pageSettings.hero_description = $('#vitrine-hero-description').html();
-            renderHeroPreview();
-        });
-
-        $(document).on('input change', '#vitrine-hero-desc-size', function () {
-            pageSettings.hero_desc_size = $(this).val();
-            renderHeroPreview();
-        });
-
-        $(document).on('click', '.vitrine-format-btn', function () {
-            var target = $(this).data('target'); // 'text' ou 'desc'
-            var prop   = $(this).data('prop');   // 'bold' ou 'italic'
-            var key    = 'hero_' + target + '_' + prop;
-            pageSettings[key] = pageSettings[key] === '1' ? '0' : '1';
-            $(this).toggleClass('is-active', pageSettings[key] === '1');
-            renderHeroPreview();
         });
 
         renderCanvas();

--- a/assets/js/hero-admin.js
+++ b/assets/js/hero-admin.js
@@ -1,0 +1,125 @@
+/**
+ * Vitrine Builder – Hero meta box (admin)
+ */
+(function ($) {
+    'use strict';
+
+    var settings = (window.vitrineHeroData && vitrineHeroData.settings) ? vitrineHeroData.settings : {};
+
+    function escapeHtml(str) {
+        return String(str || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function escapeAttr(str) {
+        return escapeHtml(str).replace(/'/g, '&#39;');
+    }
+
+    function syncDescriptionField() {
+        var html = $('#vitrine-hero-description').html();
+        $('#vitrine-hero-description-input').val(html);
+    }
+
+    function renderHeroPreview() {
+        var $prev = $('#vitrine-hero-preview');
+        if (!$prev.length) return;
+
+        var img   = $('#vitrine-hero-image').val() || '';
+        var text  = $('#vitrine-hero-text').val() || '';
+        var color = $('#vitrine-hero-text-color').val() || '#ffffff';
+        var opa   = parseInt($('#vitrine-hero-opacity').val() || '50', 10) / 100;
+        var h     = parseInt($('#vitrine-hero-height').val() || '400', 10);
+        var fs    = parseInt($('#vitrine-hero-font-size').val() || '36', 10);
+        var align = $('#vitrine-hero-text-align').val() || 'center';
+        var desc  = $('#vitrine-hero-description').html() || '';
+        var dfs   = parseInt($('#vitrine-hero-desc-size').val() || '18', 10);
+        var textBold = $('#vitrine-hero-text-bold').val() !== '0' ? '700' : '400';
+        var textItal = $('#vitrine-hero-text-italic').val() === '1' ? 'italic' : 'normal';
+
+        if (!img && !text && !desc) {
+            $prev.empty().hide();
+            return;
+        }
+
+        var justifyMap = { left: 'flex-start', center: 'center', right: 'flex-end' };
+        var justifyContent = justifyMap[align] || 'center';
+        var bgStyle = img ? 'background:url(' + escapeAttr(img) + ') center/cover no-repeat;' : 'background:#333;';
+
+        var html = '<div style="position:relative;' + bgStyle + 'height:' + h + 'px;border-radius:6px;overflow:hidden;display:flex;flex-direction:column;align-items:' + justifyContent + ';justify-content:center;gap:10px;margin-top:10px;padding:0 20px;">';
+        html += '<div style="position:absolute;inset:0;background:rgba(0,0,0,' + opa + ');"></div>';
+        if (text) {
+            html += '<span style="position:relative;z-index:1;font-size:' + fs + 'px;font-weight:' + textBold + ';font-style:' + textItal + ';color:' + escapeAttr(color) + ';text-align:' + escapeAttr(align) + ';text-shadow:0 2px 8px rgba(0,0,0,.5);">' + escapeHtml(text) + '</span>';
+        }
+        if (desc) {
+            html += '<span style="position:relative;z-index:1;font-size:' + dfs + 'px;color:' + escapeAttr(color) + ';text-align:' + escapeAttr(align) + ';opacity:0.9;text-shadow:0 1px 4px rgba(0,0,0,.5);">' + desc + '</span>';
+        }
+        html += '</div>';
+
+        $prev.html(html).show();
+    }
+
+    $(function () {
+        if (!$('#vitrine-hero-meta-box').length) return;
+
+        renderHeroPreview();
+
+        $('#vitrine-hero-select-image').on('click', function (e) {
+            e.preventDefault();
+            var frame = wp.media({ title: 'Imagem do Hero', multiple: false, library: { type: 'image' } });
+            frame.on('select', function () {
+                var url = frame.state().get('selection').first().toJSON().url;
+                $('#vitrine-hero-image').val(url);
+                var $wrap = $('.vitrine-hero-image-field');
+                $wrap.find('.vitrine-image-preview').remove();
+                $wrap.prepend('<img src="' + escapeAttr(url) + '" class="vitrine-image-preview" alt="" />');
+                if (!$('#vitrine-hero-remove-image').length) {
+                    $('#vitrine-hero-select-image').after(' <button type="button" class="button" id="vitrine-hero-remove-image">Remover</button>');
+                }
+                renderHeroPreview();
+            });
+            frame.open();
+        });
+
+        $(document).on('click', '#vitrine-hero-remove-image', function () {
+            $('#vitrine-hero-image').val('');
+            $('.vitrine-hero-image-field .vitrine-image-preview').remove();
+            $(this).remove();
+            renderHeroPreview();
+        });
+
+        $('#vitrine-hero-meta-box').on('input change', '#vitrine-hero-text, #vitrine-hero-text-color, #vitrine-hero-opacity, #vitrine-hero-height, #vitrine-hero-font-size, #vitrine-hero-text-align, #vitrine-hero-desc-size', function () {
+            if (this.id === 'vitrine-hero-opacity') {
+                $('#vitrine-hero-opacity-val').text($(this).val() + '%');
+            }
+            renderHeroPreview();
+        });
+
+        $('#vitrine-hero-description').on('input', function () {
+            syncDescriptionField();
+            renderHeroPreview();
+        });
+
+        $('#vitrine-hero-desc-toolbar .vitrine-wysiwyg-btn').on('mousedown', function (e) {
+            e.preventDefault();
+            document.execCommand($(this).data('cmd'), false, null);
+            syncDescriptionField();
+            renderHeroPreview();
+        });
+
+        $('#vitrine-hero-meta-box .vitrine-format-btn').on('click', function () {
+            var prop = $(this).data('prop');
+            var $input = prop === 'bold' ? $('#vitrine-hero-text-bold') : $('#vitrine-hero-text-italic');
+            var next = $input.val() === '1' ? '0' : '1';
+            $input.val(next);
+            $(this).toggleClass('is-active', next === '1');
+            renderHeroPreview();
+        });
+
+        $('#post').on('submit', function () {
+            syncDescriptionField();
+        });
+    });
+})(jQuery);

--- a/builder-vitrine.php
+++ b/builder-vitrine.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  Builder Vitrine
  * Description:  Editor visual de vitrines para WooCommerce/WordPress.
- * Version:      1.2.2
+ * Version:      1.2.9
  * Author:       Antonio
  * Text Domain:  builder-vitrine
  */
@@ -11,11 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'VITRINE_VERSION', '1.2.2' );
+define( 'VITRINE_VERSION', '1.2.9' );
 define( 'VITRINE_PATH',    plugin_dir_path( __FILE__ ) );
 define( 'VITRINE_URL',     plugin_dir_url( __FILE__ ) );
 
 require_once VITRINE_PATH . 'class-plugin.php';
+require_once VITRINE_PATH . 'class-vitrine-icons.php';
+require_once VITRINE_PATH . 'class-vitrine-hero.php';
 require_once VITRINE_PATH . 'class-editor.php';
 require_once VITRINE_PATH . 'class-render.php';
 

--- a/class-editor.php
+++ b/class-editor.php
@@ -45,7 +45,7 @@ class Vitrine_Editor {
             array( $this, 'render_editor' ),
             'vitrine',
             'normal',
-            'high'
+            'default'
         );
     }
 
@@ -61,6 +61,8 @@ class Vitrine_Editor {
         if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
             return;
         }
+
+        wp_enqueue_style( 'dashicons' );
 
         // Font Awesome 6 Free
         wp_enqueue_style(
@@ -120,7 +122,13 @@ class Vitrine_Editor {
 
         $post_id = get_the_ID();
         $layout  = get_post_meta( $post_id, '_vitrine_layout', true );
-        $page_settings = get_post_meta( $post_id, '_vitrine_page_settings', true );
+        $all_settings = Vitrine_Hero_Meta::get_settings( $post_id );
+        $page_settings = array(
+            'show_header'   => $all_settings['show_header'],
+            'show_footer'   => $all_settings['show_footer'],
+            'page_bg_color' => $all_settings['page_bg_color'],
+            'custom_css'    => $all_settings['custom_css'],
+        );
 
         wp_localize_script( 'vitrine-editor-js', 'vitrineData', array(
             'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
@@ -128,25 +136,8 @@ class Vitrine_Editor {
             'postId'       => $post_id,
             'elements'     => $elements_js,
             'layout'       => $layout ? $layout : array(),
-            'pageSettings' => $page_settings ? $page_settings : array(
-                'show_header'          => '1',
-                'show_footer'          => '1',
-                'page_bg_color'        => '',
-                'hero_image'           => '',
-                'hero_text'            => '',
-                'hero_text_color'      => '#ffffff',
-                'hero_overlay_opacity' => '50',
-                'hero_height'          => '400',
-                'hero_font_size'       => '36',
-                'hero_text_align'      => 'center',
-                'hero_description'     => '',
-                'hero_desc_size'       => '18',
-                'hero_text_bold'       => '1',
-                'hero_text_italic'     => '0',
-                'hero_desc_bold'       => '0',
-                'hero_desc_italic'     => '0',
-                'custom_css'           => '',
-            ),
+            'pageSettings' => $page_settings,
+            'iconPicker'   => Vitrine_Icons::get_picker_data(),
         ) );
     }
 
@@ -236,26 +227,14 @@ class Vitrine_Editor {
         $page_raw = isset( $_POST['page_settings'] ) ? wp_unslash( $_POST['page_settings'] ) : '';
         $page_settings = json_decode( $page_raw, true );
         if ( is_array( $page_settings ) ) {
-            $clean_page = array(
-                'show_header'           => ! empty( $page_settings['show_header'] ) ? '1' : '0',
-                'show_footer'           => ! empty( $page_settings['show_footer'] ) ? '1' : '0',
-                'page_bg_color'         => isset( $page_settings['page_bg_color'] ) ? sanitize_hex_color( $page_settings['page_bg_color'] ) : '',
-                'hero_image'            => isset( $page_settings['hero_image'] ) ? esc_url_raw( $page_settings['hero_image'] ) : '',
-                'hero_text'             => isset( $page_settings['hero_text'] ) ? sanitize_text_field( $page_settings['hero_text'] ) : '',
-                'hero_text_color'       => isset( $page_settings['hero_text_color'] ) ? sanitize_hex_color( $page_settings['hero_text_color'] ) : '#ffffff',
-                'hero_overlay_opacity'  => isset( $page_settings['hero_overlay_opacity'] ) ? absint( $page_settings['hero_overlay_opacity'] ) : 50,
-                'hero_height'           => isset( $page_settings['hero_height'] ) ? absint( $page_settings['hero_height'] ) : 400,
-                'hero_font_size'        => isset( $page_settings['hero_font_size'] ) ? absint( $page_settings['hero_font_size'] ) : 36,
-                'hero_text_align'       => isset( $page_settings['hero_text_align'] ) && in_array( $page_settings['hero_text_align'], array( 'left', 'center', 'right' ), true ) ? $page_settings['hero_text_align'] : 'center',
-                'hero_description'      => isset( $page_settings['hero_description'] ) ? wp_kses_post( $page_settings['hero_description'] ) : '',
-                'hero_desc_size'        => isset( $page_settings['hero_desc_size'] ) ? absint( $page_settings['hero_desc_size'] ) : 18,
-                'hero_text_bold'        => isset( $page_settings['hero_text_bold'] ) && $page_settings['hero_text_bold'] === '0' ? '0' : '1',
-                'hero_text_italic'      => ! empty( $page_settings['hero_text_italic'] ) ? '1' : '0',
-                'hero_desc_bold'        => ! empty( $page_settings['hero_desc_bold'] ) ? '1' : '0',
-                'hero_desc_italic'      => ! empty( $page_settings['hero_desc_italic'] ) ? '1' : '0',
-                'custom_css'            => isset( $page_settings['custom_css'] ) ? $this->sanitize_page_custom_css( $page_settings['custom_css'] ) : '',
+            $builder_settings = array(
+                'show_header'   => ! empty( $page_settings['show_header'] ) ? '1' : '0',
+                'show_footer'   => ! empty( $page_settings['show_footer'] ) ? '1' : '0',
+                'page_bg_color' => isset( $page_settings['page_bg_color'] ) ? sanitize_hex_color( $page_settings['page_bg_color'] ) : '',
+                'custom_css'    => isset( $page_settings['custom_css'] ) ? $this->sanitize_page_custom_css( $page_settings['custom_css'] ) : '',
             );
-            update_post_meta( $post_id, '_vitrine_page_settings', $clean_page );
+            $merged = Vitrine_Hero_Meta::merge_settings( $post_id, $builder_settings );
+            update_post_meta( $post_id, '_vitrine_page_settings', $merged );
         }
 
         wp_send_json_success( 'Layout salvo.' );

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -21,6 +21,7 @@ class Vitrine_Plugin {
 
         if ( is_admin() ) {
             new Vitrine_Editor();
+            new Vitrine_Hero_Meta();
         }
 
         new Vitrine_Render();

--- a/class-vitrine-hero.php
+++ b/class-vitrine-hero.php
@@ -1,0 +1,254 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Meta box isolado para configurações do Hero da vitrine.
+ */
+class Vitrine_Hero_Meta {
+
+    const META_KEY = '_vitrine_page_settings';
+
+    public function __construct() {
+        add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 5 );
+        add_action( 'save_post_vitrine', array( $this, 'save' ), 10, 2 );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+    }
+
+    public static function default_page_settings() {
+        return array(
+            'show_header'          => '1',
+            'show_footer'          => '1',
+            'page_bg_color'        => '',
+            'hero_image'           => '',
+            'hero_text'            => '',
+            'hero_text_color'      => '#ffffff',
+            'hero_overlay_opacity' => '50',
+            'hero_height'          => '400',
+            'hero_font_size'       => '36',
+            'hero_text_align'      => 'center',
+            'hero_description'     => '',
+            'hero_desc_size'       => '18',
+            'hero_text_bold'       => '1',
+            'hero_text_italic'     => '0',
+            'hero_desc_bold'       => '0',
+            'hero_desc_italic'     => '0',
+            'custom_css'           => '',
+        );
+    }
+
+    public static function get_settings( $post_id ) {
+        $settings = get_post_meta( $post_id, self::META_KEY, true );
+        if ( ! is_array( $settings ) ) {
+            return self::default_page_settings();
+        }
+        return wp_parse_args( $settings, self::default_page_settings() );
+    }
+
+    /**
+     * Mescla configurações parciais preservando chaves não enviadas (ex.: hero vs builder).
+     */
+    public static function merge_settings( $post_id, array $partial ) {
+        $existing = self::get_settings( $post_id );
+        return array_merge( $existing, $partial );
+    }
+
+    public static function hero_keys() {
+        return array(
+            'hero_image',
+            'hero_text',
+            'hero_text_color',
+            'hero_overlay_opacity',
+            'hero_height',
+            'hero_font_size',
+            'hero_text_align',
+            'hero_description',
+            'hero_desc_size',
+            'hero_text_bold',
+            'hero_text_italic',
+            'hero_desc_bold',
+            'hero_desc_italic',
+        );
+    }
+
+    public static function builder_keys() {
+        return array(
+            'show_header',
+            'show_footer',
+            'page_bg_color',
+            'custom_css',
+        );
+    }
+
+    public static function sanitize_hero( array $input ) {
+        $align = isset( $input['hero_text_align'] ) ? $input['hero_text_align'] : 'center';
+        if ( ! in_array( $align, array( 'left', 'center', 'right' ), true ) ) {
+            $align = 'center';
+        }
+
+        return array(
+            'hero_image'           => isset( $input['hero_image'] ) ? esc_url_raw( $input['hero_image'] ) : '',
+            'hero_text'            => isset( $input['hero_text'] ) ? sanitize_text_field( $input['hero_text'] ) : '',
+            'hero_text_color'      => isset( $input['hero_text_color'] ) ? sanitize_hex_color( $input['hero_text_color'] ) : '#ffffff',
+            'hero_overlay_opacity' => isset( $input['hero_overlay_opacity'] ) ? absint( $input['hero_overlay_opacity'] ) : 50,
+            'hero_height'          => isset( $input['hero_height'] ) ? absint( $input['hero_height'] ) : 400,
+            'hero_font_size'       => isset( $input['hero_font_size'] ) ? absint( $input['hero_font_size'] ) : 36,
+            'hero_text_align'      => $align,
+            'hero_description'     => isset( $input['hero_description'] ) ? wp_kses_post( $input['hero_description'] ) : '',
+            'hero_desc_size'       => isset( $input['hero_desc_size'] ) ? absint( $input['hero_desc_size'] ) : 18,
+            'hero_text_bold'       => ! empty( $input['hero_text_bold'] ) ? '1' : '0',
+            'hero_text_italic'     => ! empty( $input['hero_text_italic'] ) ? '1' : '0',
+            'hero_desc_bold'       => ! empty( $input['hero_desc_bold'] ) ? '1' : '0',
+            'hero_desc_italic'     => ! empty( $input['hero_desc_italic'] ) ? '1' : '0',
+        );
+    }
+
+    public function add_meta_box() {
+        add_meta_box(
+            'vitrine_hero',
+            'Hero da Vitrine',
+            array( $this, 'render_meta_box' ),
+            'vitrine',
+            'normal',
+            'high'
+        );
+    }
+
+    public function enqueue( $hook ) {
+        global $post_type;
+        if ( 'vitrine' !== $post_type || ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+            return;
+        }
+
+        wp_enqueue_media();
+        wp_enqueue_style(
+            'vitrine-hero-admin-css',
+            VITRINE_URL . 'assets/css/editor.css',
+            array(),
+            filemtime( VITRINE_PATH . 'assets/css/editor.css' )
+        );
+        wp_enqueue_script(
+            'vitrine-hero-admin-js',
+            VITRINE_URL . 'assets/js/hero-admin.js',
+            array( 'jquery' ),
+            filemtime( VITRINE_PATH . 'assets/js/hero-admin.js' ),
+            true
+        );
+
+        $post_id  = get_the_ID();
+        $settings = self::get_settings( $post_id );
+        wp_localize_script( 'vitrine-hero-admin-js', 'vitrineHeroData', array(
+            'settings' => $settings,
+        ) );
+    }
+
+    public function render_meta_box( $post ) {
+        wp_nonce_field( 'vitrine_hero_save', 'vitrine_hero_nonce' );
+
+        $s = self::get_settings( $post->ID );
+        ?>
+        <div id="vitrine-hero-meta-box" class="vitrine-hero-metabox">
+            <p class="description" style="margin-top:0;">Banner no topo da vitrine publicada. Salve ou atualize a vitrine para aplicar.</p>
+            <div class="vitrine-hero-fields">
+                <div class="vitrine-hero-field">
+                    <label for="vitrine-hero-image">Imagem de fundo</label>
+                    <div class="vitrine-image-field vitrine-hero-image-field">
+                        <?php if ( ! empty( $s['hero_image'] ) ) : ?>
+                            <img src="<?php echo esc_url( $s['hero_image'] ); ?>" class="vitrine-image-preview" alt="" />
+                        <?php endif; ?>
+                        <input type="hidden" name="vitrine_hero[hero_image]" id="vitrine-hero-image" value="<?php echo esc_attr( $s['hero_image'] ); ?>" />
+                        <button type="button" class="button" id="vitrine-hero-select-image">Selecionar</button>
+                        <?php if ( ! empty( $s['hero_image'] ) ) : ?>
+                            <button type="button" class="button" id="vitrine-hero-remove-image">Remover</button>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <div class="vitrine-hero-field">
+                    <label for="vitrine-hero-text">Frase de destaque</label>
+                    <input type="text" name="vitrine_hero[hero_text]" id="vitrine-hero-text" value="<?php echo esc_attr( $s['hero_text'] ); ?>" placeholder="Título do hero" class="widefat" />
+                    <div class="vitrine-hero-format">
+                        <button type="button" class="vitrine-format-btn<?php echo '1' === $s['hero_text_bold'] ? ' is-active' : ''; ?>" data-target="text" data-prop="bold" title="Negrito"><b>B</b></button>
+                        <button type="button" class="vitrine-format-btn<?php echo '1' === $s['hero_text_italic'] ? ' is-active' : ''; ?>" data-target="text" data-prop="italic" title="Itálico"><i>I</i></button>
+                        <input type="hidden" name="vitrine_hero[hero_text_bold]" id="vitrine-hero-text-bold" value="<?php echo esc_attr( $s['hero_text_bold'] ); ?>" />
+                        <input type="hidden" name="vitrine_hero[hero_text_italic]" id="vitrine-hero-text-italic" value="<?php echo esc_attr( $s['hero_text_italic'] ); ?>" />
+                    </div>
+                </div>
+
+                <div class="vitrine-hero-field vitrine-hero-field--row">
+                    <div>
+                        <label for="vitrine-hero-font-size">Tamanho do texto (px)</label>
+                        <input type="number" name="vitrine_hero[hero_font_size]" id="vitrine-hero-font-size" value="<?php echo esc_attr( $s['hero_font_size'] ); ?>" min="12" max="120" step="2" class="small-text" />
+                    </div>
+                    <div>
+                        <label for="vitrine-hero-text-align">Alinhamento</label>
+                        <select name="vitrine_hero[hero_text_align]" id="vitrine-hero-text-align">
+                            <option value="left"<?php selected( $s['hero_text_align'], 'left' ); ?>>Esquerda</option>
+                            <option value="center"<?php selected( $s['hero_text_align'], 'center' ); ?>>Centro</option>
+                            <option value="right"<?php selected( $s['hero_text_align'], 'right' ); ?>>Direita</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="vitrine-hero-field vitrine-hero-field--wide">
+                    <label>Descrição</label>
+                    <div class="vitrine-wysiwyg-toolbar" id="vitrine-hero-desc-toolbar">
+                        <button type="button" class="vitrine-wysiwyg-btn" data-cmd="bold" title="Negrito"><b>B</b></button>
+                        <button type="button" class="vitrine-wysiwyg-btn" data-cmd="italic" title="Itálico"><i>I</i></button>
+                        <button type="button" class="vitrine-wysiwyg-btn" data-cmd="underline" title="Sublinhado"><u>U</u></button>
+                        <button type="button" class="vitrine-wysiwyg-btn" data-cmd="removeFormat" title="Limpar formatação">&#10005;</button>
+                    </div>
+                    <div id="vitrine-hero-description" class="vitrine-aranha-wysiwyg" contenteditable="true"><?php echo wp_kses_post( $s['hero_description'] ); ?></div>
+                    <textarea name="vitrine_hero[hero_description]" id="vitrine-hero-description-input" class="hidden" style="display:none;"><?php echo esc_textarea( $s['hero_description'] ); ?></textarea>
+                </div>
+
+                <div class="vitrine-hero-field">
+                    <label for="vitrine-hero-desc-size">Tamanho da descrição (px)</label>
+                    <input type="number" name="vitrine_hero[hero_desc_size]" id="vitrine-hero-desc-size" value="<?php echo esc_attr( $s['hero_desc_size'] ); ?>" min="10" max="60" step="1" class="small-text" />
+                </div>
+
+                <div class="vitrine-hero-field">
+                    <label for="vitrine-hero-text-color">Cor do texto</label>
+                    <input type="color" name="vitrine_hero[hero_text_color]" id="vitrine-hero-text-color" value="<?php echo esc_attr( $s['hero_text_color'] ?: '#ffffff' ); ?>" />
+                </div>
+
+                <div class="vitrine-hero-field">
+                    <label for="vitrine-hero-opacity">Opacidade do fade <span id="vitrine-hero-opacity-val"><?php echo esc_html( $s['hero_overlay_opacity'] ); ?>%</span></label>
+                    <input type="range" name="vitrine_hero[hero_overlay_opacity]" id="vitrine-hero-opacity" min="0" max="100" value="<?php echo esc_attr( $s['hero_overlay_opacity'] ); ?>" />
+                </div>
+
+                <div class="vitrine-hero-field">
+                    <label for="vitrine-hero-height">Altura (px)</label>
+                    <input type="number" name="vitrine_hero[hero_height]" id="vitrine-hero-height" value="<?php echo esc_attr( $s['hero_height'] ); ?>" min="100" max="1000" step="10" class="small-text" />
+                </div>
+            </div>
+            <div id="vitrine-hero-preview"></div>
+        </div>
+        <?php
+    }
+
+    public function save( $post_id, $post ) {
+        if ( ! isset( $_POST['vitrine_hero_nonce'] ) ) {
+            return;
+        }
+        if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['vitrine_hero_nonce'] ) ), 'vitrine_hero_save' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+        if ( 'vitrine' !== $post->post_type ) {
+            return;
+        }
+
+        $raw  = isset( $_POST['vitrine_hero'] ) && is_array( $_POST['vitrine_hero'] ) ? wp_unslash( $_POST['vitrine_hero'] ) : array();
+        $hero = self::sanitize_hero( $raw );
+        $merged = self::merge_settings( $post_id, $hero );
+
+        update_post_meta( $post_id, self::META_KEY, $merged );
+    }
+}

--- a/class-vitrine-icons.php
+++ b/class-vitrine-icons.php
@@ -1,0 +1,126 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Listas completas de ícones para o picker do editor.
+ */
+class Vitrine_Icons {
+
+    /**
+     * Todos os Dashicons registrados no core do WordPress.
+     *
+     * @return string[]
+     */
+    public static function get_dashicons() {
+        static $list = null;
+        if ( null !== $list ) {
+            return $list;
+        }
+
+        $css_file = ABSPATH . WPINC . '/css/dashicons.css';
+        if ( ! is_readable( $css_file ) ) {
+            $list = array();
+            return $list;
+        }
+
+        $content = file_get_contents( $css_file );
+        if ( ! $content || ! preg_match_all( '/\.dashicons-([a-z0-9-]+):before\s*\{/', $content, $matches ) ) {
+            $list = array();
+            return $list;
+        }
+
+        $names = array_unique( $matches[1] );
+        sort( $names, SORT_STRING );
+
+        $list = array();
+        foreach ( $names as $name ) {
+            if ( 'before' === $name ) {
+                continue;
+            }
+            $list[] = 'dashicons-' . $name;
+        }
+
+        return $list;
+    }
+
+    /**
+     * Ícones Font Awesome Free (solid, regular, brands) via metadata oficial.
+     *
+     * @return string[] Ex.: "fas fa-user", "fab fa-github"
+     */
+    public static function get_fontawesome() {
+        static $list = null;
+        if ( null !== $list ) {
+            return $list;
+        }
+
+        $cached = get_transient( 'vitrine_fa_icons_list' );
+        if ( is_array( $cached ) && ! empty( $cached ) ) {
+            $list = $cached;
+            return $list;
+        }
+
+        $url      = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/metadata/icons.json';
+        $response = wp_remote_get(
+            $url,
+            array(
+                'timeout' => 20,
+                'headers' => array(
+                    'Accept' => 'application/json',
+                ),
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            $list = array();
+            return $list;
+        }
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( ! is_array( $body ) ) {
+            $list = array();
+            return $list;
+        }
+
+        $style_prefix = array(
+            'solid'   => 'fas',
+            'regular' => 'far',
+            'brands'  => 'fab',
+        );
+
+        $icons = array();
+        foreach ( $body as $name => $data ) {
+            if ( empty( $data['free'] ) || ! is_array( $data['free'] ) ) {
+                continue;
+            }
+            foreach ( $data['free'] as $style ) {
+                if ( ! isset( $style_prefix[ $style ] ) ) {
+                    continue;
+                }
+                $icons[] = $style_prefix[ $style ] . ' fa-' . $name;
+            }
+        }
+
+        $icons = array_values( array_unique( $icons ) );
+        sort( $icons, SORT_STRING );
+
+        set_transient( 'vitrine_fa_icons_list', $icons, WEEK_IN_SECONDS );
+
+        $list = $icons;
+        return $list;
+    }
+
+    /**
+     * Dados para wp_localize_script.
+     *
+     * @return array{dashicons: string[], fontawesome: string[]}
+     */
+    public static function get_picker_data() {
+        return array(
+            'dashicons'   => self::get_dashicons(),
+            'fontawesome' => self::get_fontawesome(),
+        );
+    }
+}

--- a/elements/element-aranha.php
+++ b/elements/element-aranha.php
@@ -26,6 +26,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
             'line_color'      => '#8c8c8c',
             'text_color'      => '#333333',
             'icon_size'       => '40',
+            'icon_color'      => '#333333',
             'left_items'      => array(),
             'right_items'     => array(),
             'top_items'       => array(),
@@ -41,6 +42,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
             array( 'name' => 'line_color',      'label' => 'Cor das linhas',         'type' => 'color' ),
             array( 'name' => 'text_color',      'label' => 'Cor do texto',           'type' => 'color' ),
             array( 'name' => 'icon_size',       'label' => 'Tamanho ícones (px)',    'type' => 'number' ),
+            array( 'name' => 'icon_color',      'label' => 'Cor dos ícones',         'type' => 'color' ),
         );
     }
 
@@ -49,6 +51,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
 
         $center_size = max( 80, intval( $s['center_size'] ) );
         $icon_size   = max( 16, intval( $s['icon_size'] ) );
+        $icon_color  = esc_attr( $s['icon_color'] );
         $line_color  = esc_attr( $s['line_color'] );
         $text_color  = esc_attr( $s['text_color'] );
         $bg_color    = esc_attr( $s['bg_color'] );
@@ -71,7 +74,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         if ( $top_n ) {
             $output .= '<div class="vitrine-aranha__top-row">';
             foreach ( $top_items as $idx => $item ) {
-                $output .= $this->render_top_item( $item, $icon_size, $idx, $top_n );
+                $output .= $this->render_top_item( $item, $icon_size, $icon_color, $idx, $top_n );
             }
             $output .= '</div>';
         }
@@ -82,7 +85,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         // ── Lado Esquerdo ──
         $output .= '<div class="vitrine-aranha__side vitrine-aranha__side--left">';
         foreach ( $left_items as $idx => $item ) {
-            $output .= $this->render_item( $item, 'left', $icon_size, $idx, $left_n );
+            $output .= $this->render_item( $item, 'left', $icon_size, $icon_color, $idx, $left_n );
         }
         if ( ! $left_n ) {
             $output .= '<div class="vitrine-aranha__item vitrine-aranha__item--empty"></div>';
@@ -101,7 +104,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         // ── Lado Direito ──
         $output .= '<div class="vitrine-aranha__side vitrine-aranha__side--right">';
         foreach ( $right_items as $idx => $item ) {
-            $output .= $this->render_item( $item, 'right', $icon_size, $idx, $right_n );
+            $output .= $this->render_item( $item, 'right', $icon_size, $icon_color, $idx, $right_n );
         }
         if ( ! $right_n ) {
             $output .= '<div class="vitrine-aranha__item vitrine-aranha__item--empty"></div>';
@@ -113,7 +116,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         return $output;
     }
 
-    private function render_item( $item, $side, $icon_size, $index = 0, $total = 1 ) {
+    private function render_item( $item, $side, $icon_size, $icon_color, $index = 0, $total = 1 ) {
         $text = wp_kses_post( isset( $item['text'] ) ? $item['text'] : '' );
         $icon = isset( $item['icon'] ) ? $item['icon'] : '';
         $link = isset( $item['link'] ) ? esc_url( $item['link'] ) : '';
@@ -132,13 +135,13 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         if ( 'left' === $side ) {
             $output .= '<div class="vitrine-aranha__card">';
             $output .= $this->render_text( $text, $link );
-            $output .= $this->render_icon( $icon, $icon_size );
+            $output .= $this->render_icon( $icon, $icon_size, $icon_color );
             $output .= '</div>';
             $output .= $this->render_arm( $bend, 'left' );
         } else {
             $output .= $this->render_arm( $bend, 'right' );
             $output .= '<div class="vitrine-aranha__card">';
-            $output .= $this->render_icon( $icon, $icon_size );
+            $output .= $this->render_icon( $icon, $icon_size, $icon_color );
             $output .= $this->render_text( $text, $link );
             $output .= '</div>';
         }
@@ -147,7 +150,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         return $output;
     }
 
-    private function render_top_item( $item, $icon_size, $index = 0, $total = 1 ) {
+    private function render_top_item( $item, $icon_size, $icon_color, $index = 0, $total = 1 ) {
         $text = wp_kses_post( isset( $item['text'] ) ? $item['text'] : '' );
         $icon = isset( $item['icon'] ) ? $item['icon'] : '';
         $link = isset( $item['link'] ) ? esc_url( $item['link'] ) : '';
@@ -164,7 +167,7 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
 
         $output = '<div class="vitrine-aranha__top-item">';
         $output .= '<div class="vitrine-aranha__card">';
-        $output .= $this->render_icon( $icon, $icon_size );
+        $output .= $this->render_icon( $icon, $icon_size, $icon_color );
         $output .= $this->render_text( $text, $link );
         $output .= '</div>';
         $output .= $this->render_top_arm( $bend );
@@ -209,19 +212,21 @@ class Vitrine_Element_Aranha extends Vitrine_Element {
         return '<span class="vitrine-aranha__text">' . $text . '</span>';
     }
 
-    private function render_icon( $icon, $icon_size ) {
+    private function render_icon( $icon, $icon_size, $icon_color = '' ) {
         if ( ! $icon ) {
             return '';
         }
 
+        $color_style = $icon_color ? 'color:' . esc_attr( $icon_color ) . ';' : '';
+
         // Dashicons (WordPress built-in)
         if ( strpos( $icon, 'dashicons-' ) === 0 ) {
-            return '<span class="dashicons ' . esc_attr( $icon ) . ' vitrine-aranha__icon" style="font-size:' . $icon_size . 'px;width:' . $icon_size . 'px;height:' . $icon_size . 'px;"></span>';
+            return '<span class="dashicons ' . esc_attr( $icon ) . ' vitrine-aranha__icon" style="font-size:' . $icon_size . 'px;width:' . $icon_size . 'px;height:' . $icon_size . 'px;' . $color_style . '"></span>';
         }
 
         // Font Awesome (fas, far, fab, fal, fad…)
         if ( preg_match( '/^fa[srlbd]?\s/', $icon ) ) {
-            return '<i class="' . esc_attr( $icon ) . ' vitrine-aranha__icon" style="font-size:' . $icon_size . 'px;"></i>';
+            return '<i class="' . esc_attr( $icon ) . ' vitrine-aranha__icon" style="font-size:' . $icon_size . 'px;' . $color_style . '"></i>';
         }
 
         // Imagem (URL)

--- a/elements/element-aranha2.php
+++ b/elements/element-aranha2.php
@@ -31,6 +31,7 @@ class Vitrine_Element_Aranha2 extends Vitrine_Element {
             'card_border'     => '#2e7d32',
             'text_color'      => '#1d2327',
             'icon_size'       => '36',
+            'icon_color'      => '#2e7d32',
             'radius'          => '200',
             'items'           => array(),
         );
@@ -44,6 +45,7 @@ class Vitrine_Element_Aranha2 extends Vitrine_Element {
             array( 'name' => 'center_bg_color', 'label' => 'Cor de fundo centro',   'type' => 'color' ),
             array( 'name' => 'radius',          'label' => 'Raio orbital (px)',     'type' => 'number' ),
             array( 'name' => 'icon_size',       'label' => 'Tam. ícones (px)',      'type' => 'number' ),
+            array( 'name' => 'icon_color',      'label' => 'Cor dos ícones',        'type' => 'color' ),
             array( 'name' => 'line_color',      'label' => 'Cor das linhas',        'type' => 'color' ),
             array( 'name' => 'card_bg',         'label' => 'Cor fundo card',        'type' => 'color' ),
             array( 'name' => 'card_border',     'label' => 'Cor borda card',        'type' => 'color' ),
@@ -63,6 +65,7 @@ class Vitrine_Element_Aranha2 extends Vitrine_Element {
         $center_size = max( 60, intval( $s['center_size'] ) );
         $radius      = max( 80, intval( $s['radius'] ) );
         $icon_size   = max( 16, intval( $s['icon_size'] ) );
+        $icon_color  = esc_attr( $s['icon_color'] );
         $line_color  = esc_attr( $s['line_color'] );
         $card_bg     = esc_attr( $s['card_bg'] );
         $card_border = esc_attr( $s['card_border'] );
@@ -184,7 +187,7 @@ class Vitrine_Element_Aranha2 extends Vitrine_Element {
 
             if ( $icon ) {
                 $inner .= '<span class="vitrine-aranha2__card-icon">'
-                    . $this->render_icon( $icon, $icon_size ) . '</span>';
+                    . $this->render_icon( $icon, $icon_size, $icon_color ) . '</span>';
             }
 
             if ( $text ) {
@@ -214,16 +217,17 @@ class Vitrine_Element_Aranha2 extends Vitrine_Element {
         return $output;
     }
 
-    private function render_icon( $icon, $icon_size ) {
+    private function render_icon( $icon, $icon_size, $icon_color = '' ) {
         if ( ! $icon ) {
             return '';
         }
+        $color_style = $icon_color ? 'color:' . esc_attr( $icon_color ) . ';' : '';
         if ( strpos( $icon, 'dashicons-' ) === 0 ) {
             return '<span class="dashicons ' . esc_attr( $icon )
-                . '" style="font-size:' . $icon_size . 'px;width:' . $icon_size . 'px;height:' . $icon_size . 'px;"></span>';
+                . '" style="font-size:' . $icon_size . 'px;width:' . $icon_size . 'px;height:' . $icon_size . 'px;' . $color_style . '"></span>';
         }
         if ( preg_match( '/^fa[srlbd]?\s/', $icon ) ) {
-            return '<i class="' . esc_attr( $icon ) . '" style="font-size:' . $icon_size . 'px;"></i>';
+            return '<i class="' . esc_attr( $icon ) . '" style="font-size:' . $icon_size . 'px;' . $color_style . '"></i>';
         }
         return '<img src="' . esc_url( $icon ) . '" alt=""'
             . ' style="width:' . $icon_size . 'px;height:' . $icon_size . 'px;object-fit:contain;border-radius:4px;" />';

--- a/elements/element-aranha3.php
+++ b/elements/element-aranha3.php
@@ -39,6 +39,7 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
             'image_shadow'       => '0',
             'gap'                => '16',
             'icon_size'          => '32',
+            'icon_color'         => '#2c3a1a',
             'card_height'        => '140',
             'card_text_align'    => 'top',
             'items'              => array(),
@@ -66,6 +67,7 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
             array( 'name' => 'image_shadow',        'label' => 'Sombra da imagem',            'type' => 'range', 'min' => 0, 'max' => 100 ),
             array( 'name' => 'gap',                 'label' => 'Espaçamento (px)',            'type' => 'number' ),
             array( 'name' => 'icon_size',           'label' => 'Tam. ícones (px)',            'type' => 'number' ),
+            array( 'name' => 'icon_color',          'label' => 'Cor dos ícones',              'type' => 'color' ),
             array( 'name' => 'card_height',         'label' => 'Altura dos cards (px)',       'type' => 'number' ),
             array( 'name' => 'card_text_align',     'label' => 'Alinhamento do texto',      'type' => 'select', 'options' => array( 'top' => 'Topo', 'center' => 'Meio', 'bottom' => 'Base' ) ),
         );
@@ -89,6 +91,7 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
         $center_bg          = $this->hex_to_rgba( $s['center_bg_color'], $s['center_bg_opacity'] );
         $gap                = max( 0, intval( $s['gap'] ) );
         $icon_size          = max( 16, intval( $s['icon_size'] ) );
+        $icon_color         = esc_attr( $s['icon_color'] );
         $card_height        = max( 80, intval( $s['card_height'] ) );
         $card_text_align    = $this->card_align_flex( $s['card_text_align'] );
         $center_size        = max( 120, min( 600, intval( $s['center_size'] ) ) );
@@ -123,9 +126,9 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
 
         if ( $n_items <= 2 ) {
             $output .= '<div class="vitrine-a3-frame vitrine-a3-frame--inline" style="' . esc_attr( $frame_style ) . '">';
-            $output .= $this->render_cards_group( $groups['left'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $card_height, $card_text_align, 'side' );
+            $output .= $this->render_cards_group( $groups['left'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $icon_color, $card_height, $card_text_align, 'side' );
             $output .= $this->render_image_cell( $center_image, $image_border_radius, $center_bg, $image_shadow, $center_size, $center_image_fit );
-            $output .= $this->render_cards_group( $groups['right'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $card_height, $card_text_align, 'side' );
+            $output .= $this->render_cards_group( $groups['right'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $icon_color, $card_height, $card_text_align, 'side' );
             $output .= '</div>';
         } else {
             $grid_style = 'display:grid;grid-template-columns:minmax(220px,1fr) minmax(120px,320px) minmax(220px,1fr);'
@@ -141,11 +144,11 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
             $output .= '<div class="vitrine-a3-frame vitrine-a3-frame--grid" style="' . esc_attr( $grid_style ) . '">';
 
             $output .= '<div class="vitrine-a3-band vitrine-a3-band--top" style="' . esc_attr( $band_top_style ) . '">';
-            $output .= $this->render_cards_group( $groups['top'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $card_height, $card_text_align, 'band' );
+            $output .= $this->render_cards_group( $groups['top'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $icon_color, $card_height, $card_text_align, 'band' );
             $output .= '</div>';
 
             $output .= '<div class="vitrine-a3-side vitrine-a3-side--left" style="' . esc_attr( $left_cell_style ) . '">';
-            $output .= $this->render_cards_group( $groups['left'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $card_height, $card_text_align, 'side' );
+            $output .= $this->render_cards_group( $groups['left'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $icon_color, $card_height, $card_text_align, 'side' );
             $output .= '</div>';
 
             $output .= '<div class="vitrine-a3-core-image" style="' . esc_attr( $image_cell_style ) . '">';
@@ -153,11 +156,11 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
             $output .= '</div>';
 
             $output .= '<div class="vitrine-a3-side vitrine-a3-side--right" style="' . esc_attr( $right_cell_style ) . '">';
-            $output .= $this->render_cards_group( $groups['right'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $card_height, $card_text_align, 'side' );
+            $output .= $this->render_cards_group( $groups['right'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $icon_color, $card_height, $card_text_align, 'side' );
             $output .= '</div>';
 
             $output .= '<div class="vitrine-a3-band vitrine-a3-band--bottom" style="' . esc_attr( $band_bottom_style ) . '">';
-            $output .= $this->render_cards_group( $groups['bottom'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $card_height, $card_text_align, 'band' );
+            $output .= $this->render_cards_group( $groups['bottom'], $card_bg, $title_color, $text_color, $card_border_radius, $card_border['css'], $icon_size, $icon_color, $card_height, $card_text_align, 'band' );
             $output .= '</div>';
 
             $output .= '</div>';
@@ -191,10 +194,10 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
         return $html;
     }
 
-    private function render_cards_group( $items, $card_bg, $title_color, $text_color, $border_radius, $border_css, $icon_size, $card_height, $card_text_align, $context ) {
+    private function render_cards_group( $items, $card_bg, $title_color, $text_color, $border_radius, $border_css, $icon_size, $icon_color, $card_height, $card_text_align, $context ) {
         $html = '';
         foreach ( $items as $it ) {
-            $html .= $this->render_card( $it, $card_bg, $title_color, $text_color, $border_radius, $border_css, $icon_size, $card_height, $card_text_align, $context );
+            $html .= $this->render_card( $it, $card_bg, $title_color, $text_color, $border_radius, $border_css, $icon_size, $icon_color, $card_height, $card_text_align, $context );
         }
         return $html;
     }
@@ -202,8 +205,8 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
     /**
      * Renderiza um card do grid.
      */
-    private function render_card( $it, $card_bg, $title_color, $text_color, $border_radius, $border_css, $icon_size, $card_height, $card_text_align, $context ) {
-        $title = isset( $it['title'] ) ? esc_html( $it['title'] ) : '';
+    private function render_card( $it, $card_bg, $title_color, $text_color, $border_radius, $border_css, $icon_size, $icon_color, $card_height, $card_text_align, $context ) {
+        $title = isset( $it['title'] ) ? wp_kses_post( $it['title'] ) : '';
         $text  = isset( $it['text'] )  ? wp_kses_post( $it['text'] )  : '';
         $icon  = isset( $it['icon'] )  ? $it['icon']                   : '';
         $link  = isset( $it['link'] )  ? esc_url( $it['link'] )        : '';
@@ -232,7 +235,7 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
 
             if ( $icon ) {
                 $inner .= '<span class="vitrine-a3-card-icon">'
-                    . $this->render_icon( $icon, $icon_size ) . '</span>';
+                    . $this->render_icon( $icon, $icon_size, $icon_color ) . '</span>';
             }
 
             if ( $title || $text ) {
@@ -424,16 +427,17 @@ class Vitrine_Element_Aranha3 extends Vitrine_Element {
         );
     }
 
-    private function render_icon( $icon, $icon_size ) {
+    private function render_icon( $icon, $icon_size, $icon_color = '' ) {
         if ( ! $icon ) {
             return '';
         }
+        $color_style = $icon_color ? 'color:' . esc_attr( $icon_color ) . ';' : '';
         if ( strpos( $icon, 'dashicons-' ) === 0 ) {
             return '<span class="dashicons ' . esc_attr( $icon )
-                . '" style="font-size:' . $icon_size . 'px;width:' . $icon_size . 'px;height:' . $icon_size . 'px;"></span>';
+                . '" style="font-size:' . $icon_size . 'px;width:' . $icon_size . 'px;height:' . $icon_size . 'px;' . $color_style . '"></span>';
         }
         if ( preg_match( '/^fa[srlbd]?\s/', $icon ) ) {
-            return '<i class="' . esc_attr( $icon ) . '" style="font-size:' . $icon_size . 'px;"></i>';
+            return '<i class="' . esc_attr( $icon ) . '" style="font-size:' . $icon_size . 'px;' . $color_style . '"></i>';
         }
         return '<img src="' . esc_url( $icon ) . '" alt=""'
             . ' style="width:' . $icon_size . 'px;height:' . $icon_size . 'px;object-fit:contain;border-radius:4px;" />';

--- a/elements/element-container.php
+++ b/elements/element-container.php
@@ -19,6 +19,7 @@ class Vitrine_Element_Container extends Vitrine_Element {
 
     public function defaults() {
         return array(
+            'name'          => '',
             'bg_color'      => '#f5f5f5',
             'bg_image'      => '',
             'bg_size'       => 'cover',
@@ -33,6 +34,7 @@ class Vitrine_Element_Container extends Vitrine_Element {
 
     public function fields() {
         return array(
+            array( 'name' => 'name',          'label' => 'Nome do container',               'type' => 'text' ),
             array( 'name' => 'bg_color',      'label' => 'Cor de fundo',                    'type' => 'color' ),
             array( 'name' => 'bg_image',      'label' => 'Imagem de fundo',                 'type' => 'image' ),
             array( 'name' => 'bg_size',       'label' => 'Tamanho do fundo',                'type' => 'select', 'options' => array( 'cover' => 'Cobrir (cover)', 'contain' => 'Conter (contain)', 'auto' => 'Automático' ) ),

--- a/elements/element-imagelinks.php
+++ b/elements/element-imagelinks.php
@@ -22,26 +22,19 @@ class Vitrine_Element_Imagelinks extends Vitrine_Element {
             'image'               => '',
             'image_height'        => '220',
             'image_fit'           => 'cover',
-            'caption'             => 'Conferências de Saúde',
+            'caption'             => '',
             'caption_bg'          => '#000000',
             'caption_color'       => '#ffffff',
             'caption_font_size'   => '16',
             'box_bg'              => '#e8e8e8',
-            'box_title'           => 'Sites relacionados',
+            'box_title'           => '',
             'box_title_color'     => '#333333',
             'box_title_font_size' => '16',
-            'link_color'          => '#333333',
-            'link_font_size'      => '14',
+            'content'             => '',
+            'content_color'       => '#333333',
+            'content_font_size'   => '14',
             'separator_color'     => '#333333',
             'box_padding'         => '16',
-            'items'               => array(
-                array( 'label' => 'Ministério da Saúde', 'url' => '' ),
-                array( 'label' => 'BVS MS', 'url' => '' ),
-                array( 'label' => 'BVS Brasil', 'url' => '' ),
-                array( 'label' => 'CNS', 'url' => '' ),
-                array( 'label' => 'CONASS', 'url' => '' ),
-                array( 'label' => 'CONASEMS', 'url' => '' ),
-            ),
         );
     }
 
@@ -54,13 +47,14 @@ class Vitrine_Element_Imagelinks extends Vitrine_Element {
             array( 'name' => 'caption_bg',          'label' => 'Fundo da legenda',            'type' => 'color' ),
             array( 'name' => 'caption_color',       'label' => 'Cor da legenda',              'type' => 'color' ),
             array( 'name' => 'caption_font_size',   'label' => 'Tam. legenda (px)',           'type' => 'number' ),
-            array( 'name' => 'box_bg',              'label' => 'Fundo da caixa de links',     'type' => 'color' ),
+            array( 'name' => 'box_bg',              'label' => 'Fundo da caixa de conteúdo',  'type' => 'color' ),
             array( 'name' => 'box_title',           'label' => 'Título da caixa',             'type' => 'text' ),
             array( 'name' => 'box_title_color',     'label' => 'Cor do título',               'type' => 'color' ),
             array( 'name' => 'box_title_font_size', 'label' => 'Tam. título (px)',            'type' => 'number' ),
+            array( 'name' => 'content',             'label' => 'Conteúdo abaixo da imagem',   'type' => 'textarea' ),
+            array( 'name' => 'content_color',       'label' => 'Cor do texto',                'type' => 'color' ),
+            array( 'name' => 'content_font_size',   'label' => 'Tam. texto (px)',             'type' => 'number' ),
             array( 'name' => 'separator_color',     'label' => 'Cor do separador',            'type' => 'color' ),
-            array( 'name' => 'link_color',          'label' => 'Cor dos links',               'type' => 'color' ),
-            array( 'name' => 'link_font_size',      'label' => 'Tam. links (px)',             'type' => 'number' ),
             array( 'name' => 'box_padding',         'label' => 'Espaçamento interno (px)',    'type' => 'number' ),
         );
     }
@@ -79,12 +73,11 @@ class Vitrine_Element_Imagelinks extends Vitrine_Element {
         $box_title         = esc_html( $s['box_title'] );
         $box_title_color   = esc_attr( $s['box_title_color'] );
         $box_title_size    = max( 10, intval( $s['box_title_font_size'] ) ) . 'px';
-        $link_color        = esc_attr( $s['link_color'] );
-        $link_font_size    = max( 10, intval( $s['link_font_size'] ) ) . 'px';
+        $content_color     = esc_attr( isset( $s['content_color'] ) ? $s['content_color'] : ( isset( $s['link_color'] ) ? $s['link_color'] : '#333333' ) );
+        $content_font_size = max( 10, intval( isset( $s['content_font_size'] ) ? $s['content_font_size'] : ( isset( $s['link_font_size'] ) ? $s['link_font_size'] : 14 ) ) ) . 'px';
         $separator_color   = esc_attr( $s['separator_color'] );
         $box_padding       = max( 0, intval( $s['box_padding'] ) ) . 'px';
-
-        $items = is_array( $s['items'] ) ? $s['items'] : array();
+        $content_html      = $this->get_content_html( $s );
 
         $wrap_style = '--il-img-h:' . $image_height . 'px;'
             . '--il-img-fit:' . $image_fit . ';'
@@ -94,8 +87,8 @@ class Vitrine_Element_Imagelinks extends Vitrine_Element {
             . '--il-box-bg:' . $box_bg . ';'
             . '--il-box-title-color:' . $box_title_color . ';'
             . '--il-box-title-size:' . $box_title_size . ';'
-            . '--il-link-color:' . $link_color . ';'
-            . '--il-link-size:' . $link_font_size . ';'
+            . '--il-content-color:' . $content_color . ';'
+            . '--il-content-size:' . $content_font_size . ';'
             . '--il-separator-color:' . $separator_color . ';'
             . '--il-box-padding:' . $box_padding . ';';
 
@@ -119,41 +112,60 @@ class Vitrine_Element_Imagelinks extends Vitrine_Element {
 
         $output .= '</div>';
 
-        $output .= '<div class="vitrine-imagelinks-box" style="background:' . $box_bg . ';padding:' . $box_padding . ';">';
+        if ( $box_title || $content_html ) {
+            $output .= '<div class="vitrine-imagelinks-box" style="background:' . $box_bg . ';padding:' . $box_padding . ';">';
 
-        if ( $box_title ) {
-            $output .= '<h3 class="vitrine-imagelinks-box-title" style="color:' . $box_title_color . ';font-size:' . $box_title_size . ';">'
-                . $box_title
-                . '</h3>';
-        }
-
-        if ( $box_title || ! empty( $items ) ) {
-            $output .= '<hr class="vitrine-imagelinks-separator" style="border-color:' . $separator_color . ';" />';
-        }
-
-        if ( ! empty( $items ) ) {
-            $output .= '<ul class="vitrine-imagelinks-list">';
-            foreach ( $items as $link_item ) {
-                $label = isset( $link_item['label'] ) ? esc_html( $link_item['label'] ) : '';
-                $url   = isset( $link_item['url'] ) ? esc_url( $link_item['url'] ) : '';
-                if ( ! $label ) {
-                    continue;
-                }
-                $output .= '<li class="vitrine-imagelinks-item">';
-                if ( $url ) {
-                    $output .= '<a href="' . $url . '" class="vitrine-imagelinks-link" style="color:' . $link_color . ';font-size:' . $link_font_size . ';">' . $label . '</a>';
-                } else {
-                    $output .= '<span class="vitrine-imagelinks-link vitrine-imagelinks-link--text" style="color:' . $link_color . ';font-size:' . $link_font_size . ';">' . $label . '</span>';
-                }
-                $output .= '</li>';
+            if ( $box_title ) {
+                $output .= '<h3 class="vitrine-imagelinks-box-title" style="color:' . $box_title_color . ';font-size:' . $box_title_size . ';">'
+                    . $box_title
+                    . '</h3>';
             }
-            $output .= '</ul>';
+
+            if ( $box_title && $content_html ) {
+                $output .= '<hr class="vitrine-imagelinks-separator" style="border-color:' . $separator_color . ';" />';
+            }
+
+            if ( $content_html ) {
+                $output .= '<div class="vitrine-imagelinks-content" style="color:' . $content_color . ';font-size:' . $content_font_size . ';">'
+                    . wp_kses_post( $content_html )
+                    . '</div>';
+            }
+
+            $output .= '</div>';
         }
 
-        $output .= '</div>';
         $output .= '</div>';
 
         return $output;
+    }
+
+    /**
+     * Conteúdo livre (WYSIWYG) ou conversão de layouts antigos com lista de links.
+     */
+    private function get_content_html( $settings ) {
+        if ( ! empty( $settings['content'] ) ) {
+            return $settings['content'];
+        }
+
+        if ( empty( $settings['items'] ) || ! is_array( $settings['items'] ) ) {
+            return '';
+        }
+
+        $lines = array();
+        foreach ( $settings['items'] as $link_item ) {
+            $label = isset( $link_item['label'] ) ? trim( (string) $link_item['label'] ) : '';
+            $url   = isset( $link_item['url'] ) ? trim( (string) $link_item['url'] ) : '';
+            if ( ! $label ) {
+                continue;
+            }
+            if ( $url ) {
+                $lines[] = '<a href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
+            } else {
+                $lines[] = esc_html( $label );
+            }
+        }
+
+        return implode( '<br />', $lines );
     }
 }
 


### PR DESCRIPTION
Preview pesado removido no canvas; só placeholder (buildAranhaEditorPlaceholder)
Campo cor dos ícones (icon_color) nas 3 aranhas
Drag entre zonas/posições:
Aranha 1: sort entre left_items, right_items, top_items
Aranha 2: reorder orbital mantido
Aranha 3: UI por zonas (Esquerda, Topo, Direita, Base, Automático)
TinyMCE/WYSIWYG nos textos dos itens (negrito, itálico, link, listas etc.) nas 3 aranhas
Sync do MCE antes de salvar/re-renderizar
Picker de ícones
Nova classe class-vitrine-icons.php (Dashicons completos + Font Awesome Free via CDN)
Abas: Dashicons → Font Awesome → Imagem
Lazy load do grid; dados passados em vitrineData.iconPicker
Containers
Campo Nome do container por container
Nome exibido na toolbar, cabeçalho do painel e preview interno
Imagem + Links
Elemento passa a vir vazio (sem legenda/título/links pré-preenchidos)
Lista de links removida → editor WYSIWYG livre abaixo da imagem
Campos Cor do texto e Tam. texto no lugar dos antigos de links
Compatibilidade com layouts antigos que usavam items
Outros / infra
Versão do plugin: 1.2.9
CSS do editor e frontend atualizados
class-editor.php e class-plugin.php ajustados para hero, ícones e sanitização